### PR TITLE
New config for Wikipathways

### DIFF
--- a/Qleverfiles/Qleverfile.wp
+++ b/Qleverfiles/Qleverfile.wp
@@ -1,0 +1,45 @@
+# Qleverfile for WikiPathways
+#
+# qlever get-data
+# qlever index
+# qlever start
+#
+# Limitations:
+# - does not load the ontologies (WP, GPML, ChEBI, PW, CLO, ...) yet
+
+[data]
+NAME              = wp
+RELEASE           = 20231210
+GET_DATA_URL      = https://data.wikipathways.org/${RELEASE}/rdf/
+GET_DATA_CMD      = wget -O wikipathways-rdf-void.ttl ${GET_DATA_URL}/wikipathways-${RELEASE}-rdf-void.ttl && \
+                    wget ${GET_DATA_URL}/wikipathways-${RELEASE}-rdf-wp.zip && \
+                      unzip -qq -c wikipathways-${RELEASE}-rdf-wp.zip -x wp/wpOntology.ttl > wikipathways-rdf-wp.ttl && \
+                    wget ${GET_DATA_URL}/wikipathways-${RELEASE}-rdf-gpml.zip && 
+                      unzip -qq -c wikipathways-${RELEASE}-rdf-gpml.zip -x gpml/gpmlOntology.ttl > wikipathways-rdf-gpml.ttl && \
+                    wget ${GET_DATA_URL}/wikipathways-${RELEASE}-rdf-authors.zip && \
+                      unzip -qq -c wikipathways-${RELEASE}-rdf-authors.zip > wikipathways-rdf-authors.ttl && \
+                    cat wikipathways-rdf-*.ttl | grep ^@prefix | tr -s ' ' | sort -u > ${NAME}.prefix-definitions
+INDEX_DESCRIPTION = WikiPathways RDF, data from ${GET_DATA_URL}
+TEXT_DESCRIPTION  = All literals, search with FILTER KEYWORDS(?text, "...")
+
+[index]
+NAME              = wp
+FILE_NAMES        = ${NAME}.prefix-definitions wikipathways-rdf-wp.ttl wikipathways-rdf-gpml.ttl wikipathways-rdf-void.ttl wikipathways-rdf-authors.ttl
+CAT_FILES         = cat ${FILE_NAMES}
+SETTINGS_JSON     = { "ascii-prefixes-only": false, "num-triples-per-batch": 1000000 }
+WITH_TEXT_INDEX   = from_literals
+
+[server]
+PORT               = 7015
+ACCESS_TOKEN       = ${data:NAME}_7643543846
+MEMORY_FOR_QUERIES = 30G
+CACHE_MAX_SIZE     = 5G
+WITH_TEXT_INDEX    = from_literals
+
+[docker]
+USE_DOCKER = true
+IMAGE      = adfreiburg/qlever
+
+[ui]
+PORT   = 7001
+CONFIG = default

--- a/README.md
+++ b/README.md
@@ -1,44 +1,53 @@
 # QLever Control
 
+**Important: Use the `python-qlever` branch of this repository. The `main` branch
+only works with bash on certain Linux systems and is no longer maintained.**
+
 This is a very small repository. Its main contents is a script `qlever`
 that can control everything that QLever does. The script is supposed to be very
-easy to use and pretty much self-explanatory as you use it. If you use docker, you
-don't even have to download any QLever code (docker will pull anything it needs)
+easy to use and pretty much self-explanatory as you use it. If you use Docker, you
+don't even have to download any QLever code (Docker will pull anything it needs)
 and the script is all you need.
 
 # Directory structure
 
-We recommend that you have a directory "qlever" for all things QLever on your machine,
-with subdirectories for the different components, in particular: "qlever-control" (this
-repository), "qlever-indices" (with a subfolder for each of your datasets), and "qlever-code"
-(only needed if you don't want to use docker, but compile the binaries on your machine).
+We recommend that you have a directory `qlever` for all things QLever on your machine,
+with subdirectories for the different components, in particular: `qlever-control` (this
+repository), `qlever-indices` (with a subfolder for each of your datasets), and `qlever-code`
+(only needed if you want to compile the QLever binaries on your machine instead of using
+Docker).
+
+Make sure that the `qlever-control` directory (which contains the `qlever` script) is in
+your `PATH`. If you have compiled QLever binaries, the directory `qlever-code/build`
+(which contains these binaries) should also be in your `PATH`. Note that Docker is easier
+to use, but typically 10 - 20% slower compared to using the binaries directly.
 
 # Quickstart
 
-Create an empty directory (preferably as a subdirectory of "qlever-indices", go there,
-and call the `qlever` script once with its full path and a dot and a space preceding it,
-and the name of a preconfiguration as only argument. For example:
-
-```. /path/to/qlever olympics```
-
-This will create a `Qleverfile` preconfigured for the
-[120 Years of Olympics](https://github.com/wallscope/olympics-rdf) dataset, which is
-a great dataset to get started because it's small. Other options are:
-`scientists` (another small test collection), `dblp` (larger), `wikidata` (very large),
-and more. If you leave out the argument, you get a default `Qleverfile`, which you need
-to edit first to use for your own dataset (it should be self-explanatory, after you have
-played around with and looked at one of the preconfigured Qleverfiles).
-
-Now you can call `qlever` without path and without a dot and a space preceding it and
-with one or more actions as argument. To see the set of avaiable actions, just use the
-autocompletion. When you are a first-timer, execute these commands one after the other
-(without the comments):
+Create an empty directory as a subdirectory of `qlever-indices` (see the previous section),
+go there, and call 
 
 ```
-qlever get-data       # Download the dataset
-qlever index          # Build a QLever index for your data
-qlever start          # Start a QLever server using that index
-qlever example-query  # Launch an example query 
+eval "$(qlever setup-autocompletion)"
+qlever setup-config olympics
+```
+The first line will enable autocompletion for the `qlever` script, which is very useful. You can also
+put that line in your `.bashrc` (or similar file if you are using another shell). The second
+line will create a `Qleverfile` preconfigured for the
+[120 Years of Olympics](https://github.com/wallscope/olympics-rdf) dataset, which is a great
+dataset to get started because it is small. To see the list of all available configs, type
+`qlever help` or just `qlever`. A dataset that is more interesting and larger, but can still
+be downloaded and indexed in a matter of minutes is `dblp`. Have a look at the `Qleverfile` and see
+whether the entries make sense (most of them are self-explanatory).
+
+Now you can download the data, build an index for it (which QLever then uses to answer queries
+efficiently), start the server, and launch a test query as follows:
+
+```
+qlever get-data
+qlever index
+qlever start
+qlever test-query
 ```
 
 Each command will not only execute the respective action, but it will also show you
@@ -56,5 +65,6 @@ You can also perform a sequence of actions with a single call, for example:
 qlever stop remove-index index start
 ```
 
-There are many more actions. The script supports autocompletion. Just type "qlever "
-and then TAB and you will get a list of all the available actions.
+There are many more actions. If you have enabled the autocompletion as described above,
+you can just type `qlever ` and then TAB and you will get a list of all the available
+actions.


### PR DESCRIPTION
Hi, I watched the https://www.youtube.com/watch?v=IJHyjdoSN54 recording today and excited about the progress being made. As I wanted to learn the `Qleverfile` idea, I created one for WikiPathways. I notice the format is not quite like that of the other files in this folder, and like to request feedback. For example, it's a bit hacky, as WikiPathways release their RDF as three zip files and one turtle file. Also, in the `sparql.wikipathways.org` endpoint, we also have ontologies loaded, which I will want to add at some point too. Final point, I want to try to replace the `RELEASE` with `current` instead of a date. But that will require some more work, the 'current' does not include the RDF anyway (to be fixed).

When it is fine, I am hoping you want to include this at some point.