### PR TITLE
Fix `qlever stop` taking a long time

### DIFF
--- a/src/qlever/__main__.py
+++ b/src/qlever/__main__.py
@@ -579,6 +579,7 @@ class Actions:
                        f" -w /index"
                        f" --entrypoint bash"
                        f" --name {docker_config['container_server']}"
+                       f" --init"
                        f" {docker_config['image']}"
                        f" -c {shlex.quote(cmdline)}")
         else:


### PR DESCRIPTION
The problem was that in the previous setup SIGNALS were not forwarded. Every `qlever stop` thus waited until docker forcefully terminated the container after 10s. `--init` starts an init process in the container that forwards SIGNALS. The containers now stop instantly.

Some technical background: https://hynek.me/articles/docker-signals/