### PR TITLE
Fix typo in Qleverfile.wikidata

### DIFF
--- a/src/qlever/Qleverfiles/Qleverfile.wikidata
+++ b/src/qlever/Qleverfiles/Qleverfile.wikidata
@@ -12,7 +12,7 @@ DESCRIPTION  = "Full Wikidata dump from ${GET_DATA_URL} (latest-all.ttl.bz2 and 
 
 [index]
 INPUT_FILES     = latest-lexemes.ttl.bz2 latest-all.ttl.bz2 
-CAT_INPUT_FILES = bzcat ${FILE_NAMES}
+CAT_INPUT_FILES = bzcat ${INPUT_FILES}
 SETTINGS_JSON   = { "languages-internal": [], "prefixes-external": [""], "locale": { "language": "en", "country": "US", "ignore-punctuation": true }, "ascii-prefixes-only": false, "num-triples-per-batch": 5000000 }
 STXXL_MEMORY    = 10G
 


### PR DESCRIPTION
Before this change, I would encounter this error message after running `qlever get-data`:

`Error parsing Qleverfile Qleverfile: Bad value substitution: option 'cat_input_files' in section 'index' contains an interpolation key 'FILE_NAMES' which is not a valid option name. Raw value: 'bzcat ${FILE_NAMES}'`