### PR TITLE
Fix Qleverfile.pubchem

### DIFF
--- a/src/qlever/Qleverfiles/Qleverfile.pubchem
+++ b/src/qlever/Qleverfiles/Qleverfile.pubchem
@@ -48,7 +48,7 @@ DESCRIPTION       = PubChem RDF from ${GET_DATA_URL}, version ${DATE} (all folde
 
 [index]
 INPUT_FILES     = pubchem.additional-ontologies.nt.gz nt.${DATE}/*.nt.gz
-CAT_INPUT_FILES = zcat ${FILE_NAMES}
+CAT_INPUT_FILES = zcat ${INPUT_FILES}
 SETTINGS_JSON   = { "languages-internal": [], "prefixes-external": [""], "ascii-prefixes-only": false, "num-triples-per-batch": 1000000 }
 STXXL_MEMORY    = 10G
 


### PR DESCRIPTION
Fixing error:
Error parsing Qleverfile `Qleverfile`: Bad value substitution: option 'cat_input_files' in section 'index' contains an interpolation key 'FILE_NAMES' which is not a valid option name. Raw value: 'zcat ${FILE_NAMES}'