### PR TITLE
Update Qleverfile.pubchem

### DIFF
--- a/src/qlever/Qleverfiles/Qleverfile.pubchem
+++ b/src/qlever/Qleverfiles/Qleverfile.pubchem
@@ -47,7 +47,7 @@ GET_DATA_CMD      = mkdir -p ttl.${DATE} && mkdir -p nt.${DATE} && ${MAKE_GET_DA
 DESCRIPTION       = PubChem RDF from ${GET_DATA_URL}, version ${DATE} (all folders except nbr2d and nbr3d)
 
 [index]
-INPUT_FILES     = pubchem.additional-ontologies.nt.gz nt.${DATE}/*.nt.gz
+INPUT_FILES     =  nt.${DATE}/*.nt.gz
 CAT_INPUT_FILES = zcat ${INPUT_FILES}
 SETTINGS_JSON   = { "languages-internal": [], "prefixes-external": [""], "ascii-prefixes-only": false, "num-triples-per-batch": 1000000 }
 STXXL_MEMORY    = 10G


### PR DESCRIPTION
Fixing error:
```
qlever index --system=native

To enable autocompletion, run the following command, and consider adding it to your `.bashrc` or `.zshrc`:

eval "$(register-python-argcomplete qlever)" && export QLEVER_ARGCOMPLETE_ENABLED=1


Command: index

echo '{ "languages-internal": [], "prefixes-external": [""], "ascii-prefixes-only": false, "num-triples-per-batch": 1000000 }' > pubchem.settings.json
ulimit -Sn 1048576; zcat pubchem.additional-ontologies.nt.gz nt.2024-02-03/*.nt.gz | IndexBuilderMain -F ttl -f - -i pubchem -s pubchem.settings.json --stxxl-memory 10G | tee pubchem.index-log.txt

No file matching "pubchem.additional-ontologies.nt.gz" found

Did you call `qlever get-data`? If you did, check GET_DATA_CMD and INPUT_FILES in the QLeverfile
```