### PR TITLE
Update index.py

### DIFF
--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -64,7 +64,7 @@ class IndexCommand(QleverCommand):
         total_file_size = get_total_file_size(
                 shlex.split(args.input_files))
         if total_file_size > 1e10:
-            index_cmd = f"ulimit -Sn 1048576; {index_cmd}"
+            index_cmd = f"ulimit -Hn 1048576 && ulimit -Sn 1048576 && {index_cmd}"
 
         # Run the command in a container (if so desired).
         if args.system in Containerize.supported_systems():


### PR DESCRIPTION
Setting soft limit (ulimit -Sn) might fail if hard limit is lower (ulimit -Hn). Also, since ";" separator was used the error was only detected at the end of the IndexBuilderMain execution. Now both limits will be set and the IndexBuilderMain will only run if the ulimit succeeds.