### PR TITLE
Fix option for UI port as well as some spelling errors

### DIFF
--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -51,7 +51,7 @@ class Qleverfile:
                 help="A concise description of the dataset")
         data_args["text_description"] = arg(
                 "--text-description", type=str, default=None,
-                help="A concice description of the addtional text data"
+                help="A concise description of the additional text data"
                      " if any")
 
         index_args["input_files"] = arg(
@@ -173,7 +173,7 @@ class Qleverfile:
                 help="The name of the container used by `qlever start`")
 
         ui_args["ui_port"] = arg(
-                "--ui_port", type=int, default=7000,
+                "--ui-port", type=int, default=7000,
                 help="The port of the Qlever UI when running `qlever ui`")
         ui_args["ui_config"] = arg(
                 "--ui-config", type=str, default="default",


### PR DESCRIPTION
The option for the UI port was mistakenly called `--ui_port`, it is now called `--ui-port` analogously to how other options are named.