### PR TITLE
Fix Typo: passwort → password

### DIFF
--- a/src/qlever/commands/ui.py
+++ b/src/qlever/commands/ui.py
@@ -65,5 +65,5 @@ class UiCommand(QleverCommand):
         # Success.
         log.info(f"The QLever UI should now be up at {ui_url} ..."
                  f"You can log in as QLever UI admin with username and "
-                 f"passwort \"demo\"")
+                 f"password \"demo\"")
         return True

--- a/src/qlever/qlever_old.py
+++ b/src/qlever/qlever_old.py
@@ -985,7 +985,7 @@ class Actions:
         log.info(f"The QLever UI should now be up at "
                  f"http://{host_name}:{self.config['ui']['port']}")
         log.info("You can log in as QLever UI admin with username and "
-                 "passwort \"demo\"")
+                 "password \"demo\"")
 
     @track_action_rank
     def action_cache_stats_and_settings(self, only_show=False):


### PR DESCRIPTION
Hi,

I just a very simple PR to fix a typo (passwort → password).
I saw it while starting QLever UI using `qlever ui`.