### PR TITLE
Change default UI port for QLever UI to 8176

### DIFF
--- a/src/qlever/Qleverfiles/Qleverfile.dbpedia
+++ b/src/qlever/Qleverfiles/Qleverfile.dbpedia
@@ -27,5 +27,5 @@ SYSTEM = docker
 IMAGE  = docker.io/adfreiburg/qlever:latest
 
 [ui]
-UI_PORT   = 7000
+UI_PORT   = 9000
 UI_CONFIG = dbpedia

--- a/src/qlever/Qleverfiles/Qleverfile.dbpedia
+++ b/src/qlever/Qleverfiles/Qleverfile.dbpedia
@@ -27,5 +27,4 @@ SYSTEM = docker
 IMAGE  = docker.io/adfreiburg/qlever:latest
 
 [ui]
-UI_PORT   = 9000
 UI_CONFIG = dbpedia

--- a/src/qlever/Qleverfiles/Qleverfile.default
+++ b/src/qlever/Qleverfiles/Qleverfile.default
@@ -47,5 +47,5 @@ IMAGE  = docker.io/adfreiburg/qlever:latest
 # It determines the example queries and which SPARQL queries are launched to
 # obtain suggestions as you type a query.
 [ui]
-UI_PORT   = 7000
+UI_PORT   = 9000
 UI_CONFIG = default

--- a/src/qlever/Qleverfiles/Qleverfile.default
+++ b/src/qlever/Qleverfiles/Qleverfile.default
@@ -47,5 +47,5 @@ IMAGE  = docker.io/adfreiburg/qlever:latest
 # It determines the example queries and which SPARQL queries are launched to
 # obtain suggestions as you type a query.
 [ui]
-UI_PORT   = 9000
+UI_PORT   = 8176
 UI_CONFIG = default

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -173,7 +173,7 @@ class Qleverfile:
                 help="The name of the container used by `qlever start`")
 
         ui_args["ui_port"] = arg(
-                "--ui_port", type=int, default=7000,
+                "--ui_port", type=int, default=9000,
                 help="The port of the Qlever UI when running `qlever ui`")
         ui_args["ui_config"] = arg(
                 "--ui-config", type=str, default="default",

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -173,7 +173,7 @@ class Qleverfile:
                 help="The name of the container used by `qlever start`")
 
         ui_args["ui_port"] = arg(
-                "--ui_port", type=int, default=9000,
+                "--ui_port", type=int, default=8176,
                 help="The port of the Qlever UI when running `qlever ui`")
         ui_args["ui_config"] = arg(
                 "--ui-config", type=str, default="default",


### PR DESCRIPTION
The default for the QLever UI was 7000, but this port is not available on macOS (which is used by a lot of our users). We now take port 8176, which happens to be the concatenated ASCII codes of the first two letters of QLever and is *not* listed on https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers as a widely used port (neither officially nor unofficially). Fixes #49