### PR TITLE
Add Qlevefile variable `FORMAT` , with support for `ttl`, `nt`, and `nq`

### DIFF
--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -25,7 +25,7 @@ class IndexCommand(QleverCommand):
         return True
 
     def relevant_qleverfile_arguments(self) -> dict[str: list[str]]:
-        return {"data": ["name"],
+        return {"data": ["name", "format"],
                 "index": ["input_files", "cat_input_files", "settings_json",
                           "index_binary",
                           "only_pso_and_pos_permutations", "use_patterns",
@@ -41,7 +41,7 @@ class IndexCommand(QleverCommand):
     def execute(self, args) -> bool:
         # Construct the command line.
         index_cmd = (f"{args.cat_input_files} | {args.index_binary}"
-                     f" -F ttl -f -"
+                     f" -F {args.format} -"
                      f" -i {args.name}"
                      f" -s {args.name}.settings.json")
         if args.only_pso_and_pos_permutations:

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -53,6 +53,10 @@ class Qleverfile:
                 "--text-description", type=str, default=None,
                 help="A concice description of the addtional text data"
                      " if any")
+        data_args["format"] = arg(
+                "--format", type=str, default="ttl",
+                choices=["ttl", "nt", "nq"],
+                help="The format of the data")
 
         index_args["input_files"] = arg(
                 "--input-files", type=str, required=True,


### PR DESCRIPTION
So far, the only input formats supported were NTriples and Turtle. In QLever, they both use the same (Turtle) parser, so the `qlever` script always called `IndexBuilderMain` with option `-F ttl`. Since we are now approaching support of named graphs, add a config variable `FORMAT` with the options `nt`, `ttl`, *and* `nq`, which then become the argument of the `-F` option in the call to `IndexBuilderMain`.