### PR TITLE
Refactor the `start` command and add unit tests

### DIFF
--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -13,6 +13,91 @@ from qlever.log import log
 from qlever.util import is_qlever_server_alive, run_command
 
 
+# Construct the command line based on the config file.
+def construct_command_line(args) -> str:
+    start_cmd = (f"{args.server_binary}"
+                 f" -i {args.name}"
+                 f" -j {args.num_threads}"
+                 f" -p {args.port}"
+                 f" -m {args.memory_for_queries}"
+                 f" -c {args.cache_max_size}"
+                 f" -e {args.cache_max_size_single_entry}"
+                 f" -k {args.cache_max_num_entries}")
+    if args.timeout:
+        start_cmd += f" -s {args.timeout}"
+    if args.access_token:
+        start_cmd += f" -a {args.access_token}"
+    if args.only_pso_and_pos_permutations:
+        start_cmd += " --only-pso-and-pos-permutations"
+    if not args.use_patterns:
+        start_cmd += " --no-patterns"
+    if args.use_text_index == "yes":
+        start_cmd += " -t"
+    start_cmd += f" > {args.name}.server-log.txt 2>&1"
+    return start_cmd
+
+
+# Kill existing server on the same port
+def kill_existing_server(args) -> None:
+    args.cmdline_regex = f"^ServerMain.* -p {args.port}"
+    args.no_containers = True
+    StopCommand().execute(args)
+    log.info("")
+
+
+# Run the command in a container
+def run_command_in_container(args, start_cmd) -> str:
+    if not args.server_container:
+        args.server_container = f"qlever.server.{args.name}"
+    start_cmd = Containerize().containerize_command(
+        start_cmd,
+        args.system, "run -d --restart=unless-stopped",
+        args.image,
+        args.server_container,
+        volumes=[("$(pwd)", "/index")],
+        ports=[(args.port, args.port)],
+        working_directory="/index")
+    return start_cmd
+
+
+# When running natively, check if the binary exists and works.
+def check_binary(binary) -> bool:
+    try:
+        run_command(f"{binary} --help")
+        return True
+    except Exception as e:
+        log.error(f"Running \"{binary}\" failed, "
+                  f"set `--server-binary` to a different binary or "
+                  f"set `--system to a container system`")
+        log.info("")
+        log.info(f"The error message was: {e}")
+        return False
+
+
+# Set the access token if specified. Try to set the index description
+def setting_index_description(access_arg, port, desc) -> None:
+    curl_cmd = (f"curl -Gs http://localhost:{port}/api"
+                f" --data-urlencode \"index-description={desc}\""
+                f" {access_arg} > /dev/null")
+    log.debug(curl_cmd)
+    try:
+        run_command(curl_cmd)
+    except Exception as e:
+        log.error(f"Setting the index description failed ({e})")
+
+
+# Set the access token if specified. Try to set the text description
+def setting_text_description(access_arg, port, text_desc) -> None:
+    curl_cmd = (f"curl -Gs http://localhost:{port}/api"
+                f" --data-urlencode \"text-description={text_desc}\""
+                f" {access_arg} > /dev/null")
+    log.debug(curl_cmd)
+    try:
+        run_command(curl_cmd)
+    except Exception as e:
+        log.error(f"Setting the text description failed ({e})")
+
+
 class StartCommand(QleverCommand):
     """
     Class for executing the `start` command.
@@ -70,45 +155,15 @@ class StartCommand(QleverCommand):
 
         # Kill existing server on the same port if so desired.
         if args.kill_existing_with_same_port:
-            args.cmdline_regex = f"^ServerMain.* -p {args.port}"
-            args.no_containers = True
-            StopCommand().execute(args)
-            log.info("")
+            kill_existing_server(args)
 
         # Construct the command line based on the config file.
-        start_cmd = (f"{args.server_binary}"
-                     f" -i {args.name}"
-                     f" -j {args.num_threads}"
-                     f" -p {args.port}"
-                     f" -m {args.memory_for_queries}"
-                     f" -c {args.cache_max_size}"
-                     f" -e {args.cache_max_size_single_entry}"
-                     f" -k {args.cache_max_num_entries}")
-        if args.timeout:
-            start_cmd += f" -s {args.timeout}"
-        if args.access_token:
-            start_cmd += f" -a {args.access_token}"
-        if args.only_pso_and_pos_permutations:
-            start_cmd += " --only-pso-and-pos-permutations"
-        if not args.use_patterns:
-            start_cmd += " --no-patterns"
-        if args.use_text_index == "yes":
-            start_cmd += " -t"
-        start_cmd += f" > {args.name}.server-log.txt 2>&1"
+        start_cmd = construct_command_line(args)
 
         # Run the command in a container (if so desired). Otherwise run with
         # `nohup` so that it keeps running after the shell is closed.
         if args.system in Containerize.supported_systems():
-            if not args.server_container:
-                args.server_container = f"qlever.server.{args.name}"
-            start_cmd = Containerize().containerize_command(
-                    start_cmd,
-                    args.system, "run -d --restart=unless-stopped",
-                    args.image,
-                    args.server_container,
-                    volumes=[("$(pwd)", "/index")],
-                    ports=[(args.port, args.port)],
-                    working_directory="/index")
+            start_cmd = run_command_in_container(args, start_cmd)
         else:
             start_cmd = f"nohup {start_cmd} &"
 
@@ -119,14 +174,7 @@ class StartCommand(QleverCommand):
 
         # When running natively, check if the binary exists and works.
         if args.system == "native":
-            try:
-                run_command(f"{args.server_binary} --help")
-            except Exception as e:
-                log.error(f"Running \"{args.server_binary}\" failed, "
-                          f"set `--server-binary` to a different binary or "
-                          f"set `--system to a container system`")
-                log.info("")
-                log.info(f"The error message was: {e}")
+            if not check_binary(args.server_binary):
                 return False
 
         # Check if a QLever server is already running on this port.
@@ -142,7 +190,6 @@ class StartCommand(QleverCommand):
             args.cmdline_regex = f"^ServerMain.* -p *{port}"
             log.info("")
             StatusCommand().execute(args)
-
             return False
 
         # Remove already existing container.
@@ -183,25 +230,9 @@ class StartCommand(QleverCommand):
         # Set the access token if specified.
         access_arg = f"--data-urlencode \"access-token={args.access_token}\""
         if args.description:
-            desc = args.description
-            curl_cmd = (f"curl -Gs http://localhost:{port}/api"
-                        f" --data-urlencode \"index-description={desc}\""
-                        f" {access_arg} > /dev/null")
-            log.debug(curl_cmd)
-            try:
-                run_command(curl_cmd)
-            except Exception as e:
-                log.error(f"Setting the index description failed ({e})")
+            setting_index_description(access_arg, port, args.description)
         if args.text_description:
-            text_desc = args.text_description
-            curl_cmd = (f"curl -Gs http://localhost:{port}/api"
-                        f" --data-urlencode \"text-description={text_desc}\""
-                        f" {access_arg} > /dev/null")
-            log.debug(curl_cmd)
-            try:
-                run_command(curl_cmd)
-            except Exception as e:
-                log.error(f"Setting the text description failed ({e})")
+            setting_text_description(access_arg, port, args.text_description)
 
         # Kill the tail process. NOTE: `tail_proc.kill()` does not work.
         tail_proc.terminate()

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -23,6 +23,7 @@ def construct_command_line(args) -> str:
                  f" -c {args.cache_max_size}"
                  f" -e {args.cache_max_size_single_entry}"
                  f" -k {args.cache_max_num_entries}")
+
     if args.timeout:
         start_cmd += f" -s {args.timeout}"
     if args.access_token:
@@ -47,12 +48,6 @@ def kill_existing_server(args) -> bool:
         return False
     log.info("")
     return True
-"""def kill_existing_server(args) -> bool:
-    args.cmdline_regex = f"^ServerMain.* -p {args.port}"
-    args.no_containers = True
-    log.info("")
-    return StopCommand().execute(args)
-    """
 
 # Run the command in a container
 def run_command_in_container(args, start_cmd) -> str:
@@ -168,10 +163,8 @@ class StartCommand(QleverCommand):
 
         # Kill existing server on the same port if so desired.
         if args.kill_existing_with_same_port:
-            """ if not kill_existing_server(args):
-                log.error(f"Kill existing QLever server failed ")
-                return False"""
-            if not kill_existing_server(args):
+            if (args.kill_existing_with_same_port and
+                    not kill_existing_server(args)):
                 return False
 
         # Construct the command line based on the config file.

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -13,99 +13,6 @@ from qlever.log import log
 from qlever.util import is_qlever_server_alive, run_command
 
 
-# Construct the command line based on the config file.
-def construct_command_line(args) -> str:
-    start_cmd = (f"{args.server_binary}"
-                 f" -i {args.name}"
-                 f" -j {args.num_threads}"
-                 f" -p {args.port}"
-                 f" -m {args.memory_for_queries}"
-                 f" -c {args.cache_max_size}"
-                 f" -e {args.cache_max_size_single_entry}"
-                 f" -k {args.cache_max_num_entries}")
-
-    if args.timeout:
-        start_cmd += f" -s {args.timeout}"
-    if args.access_token:
-        start_cmd += f" -a {args.access_token}"
-    if args.only_pso_and_pos_permutations:
-        start_cmd += " --only-pso-and-pos-permutations"
-    if not args.use_patterns:
-        start_cmd += " --no-patterns"
-    if args.use_text_index == "yes":
-        start_cmd += " -t"
-    start_cmd += f" > {args.name}.server-log.txt 2>&1"
-    return start_cmd
-
-
-# Kill existing server on the same port. Trust that StopCommand() works?
-# Maybe return StopCommand().execute(args) and handle it with a try except?
-def kill_existing_server(args) -> bool:
-    args.cmdline_regex = f"^ServerMain.* -p {args.port}"
-    args.no_containers = True
-    if not StopCommand().execute(args):
-        log.error("Stopping the existing server failed")
-        return False
-    log.info("")
-    return True
-
-# Run the command in a container
-def run_command_in_container(args, start_cmd) -> str:
-    if not args.server_container:
-        args.server_container = f"qlever.server.{args.name}"
-    start_cmd = Containerize().containerize_command(
-        start_cmd,
-        args.system, "run -d --restart=unless-stopped",
-        args.image,
-        args.server_container,
-        volumes=[("$(pwd)", "/index")],
-        ports=[(args.port, args.port)],
-        working_directory="/index")
-    return start_cmd
-
-
-# When running natively, check if the binary exists and works.
-def check_binary(binary) -> bool:
-    try:
-        run_command(f"{binary} --help")
-        return True
-    except Exception as e:
-        log.error(f"Running \"{binary}\" failed, "
-                  f"set `--server-binary` to a different binary or "
-                  f"set `--system to a container system`")
-        log.info("")
-        log.info(f"The error message was: {e}")
-        return False
-
-
-# Set the access token if specified. Try to set the index description
-def setting_index_description(access_arg, port, desc) -> bool:
-    curl_cmd = (f"curl -Gs http://localhost:{port}/api"
-                f" --data-urlencode \"index-description={desc}\""
-                f" {access_arg} > /dev/null")
-    log.debug(curl_cmd)
-    try:
-        run_command(curl_cmd)
-    except Exception as e:
-        log.error(f"Setting the index description failed ({e})")
-        return False
-    return True
-
-
-# Set the access token if specified. Try to set the text description
-def setting_text_description(access_arg, port, text_desc) -> bool:
-    curl_cmd = (f"curl -Gs http://localhost:{port}/api"
-                f" --data-urlencode \"text-description={text_desc}\""
-                f" {access_arg} > /dev/null")
-    log.debug(curl_cmd)
-    try:
-        run_command(curl_cmd)
-    except Exception as e:
-        log.error(f"Setting the text description failed ({e})")
-        return False
-    return True
-
-
 class StartCommand(QleverCommand):
     """
     Class for executing the `start` command.
@@ -163,17 +70,47 @@ class StartCommand(QleverCommand):
 
         # Kill existing server on the same port if so desired.
         if args.kill_existing_with_same_port:
-            if (args.kill_existing_with_same_port and
-                    not kill_existing_server(args)):
+            args.cmdline_regex = f"^ServerMain.* -p {args.port}"
+            args.no_containers = True
+            if not StopCommand().execute(args):
+                log.error("Stopping the existing server failed")
                 return False
+            log.info("")
 
         # Construct the command line based on the config file.
-        start_cmd = construct_command_line(args)
+        start_cmd = (f"{args.server_binary}"
+                     f" -i {args.name}"
+                     f" -j {args.num_threads}"
+                     f" -p {args.port}"
+                     f" -m {args.memory_for_queries}"
+                     f" -c {args.cache_max_size}"
+                     f" -e {args.cache_max_size_single_entry}"
+                     f" -k {args.cache_max_num_entries}")
+        if args.timeout:
+            start_cmd += f" -s {args.timeout}"
+        if args.access_token:
+            start_cmd += f" -a {args.access_token}"
+        if args.only_pso_and_pos_permutations:
+            start_cmd += " --only-pso-and-pos-permutations"
+        if not args.use_patterns:
+            start_cmd += " --no-patterns"
+        if args.use_text_index == "yes":
+            start_cmd += " -t"
+        start_cmd += f" > {args.name}.server-log.txt 2>&1"
 
         # Run the command in a container (if so desired). Otherwise run with
         # `nohup` so that it keeps running after the shell is closed.
         if args.system in Containerize.supported_systems():
-            start_cmd = run_command_in_container(args, start_cmd)
+            if not args.server_container:
+                args.server_container = f"qlever.server.{args.name}"
+            start_cmd = Containerize().containerize_command(
+                    start_cmd,
+                    args.system, "run -d --restart=unless-stopped",
+                    args.image,
+                    args.server_container,
+                    volumes=[("$(pwd)", "/index")],
+                    ports=[(args.port, args.port)],
+                    working_directory="/index")
         else:
             start_cmd = f"nohup {start_cmd} &"
 
@@ -184,7 +121,14 @@ class StartCommand(QleverCommand):
 
         # When running natively, check if the binary exists and works.
         if args.system == "native":
-            if not check_binary(args.server_binary):
+            try:
+                run_command(f"{args.server_binary} --help")
+            except Exception as e:
+                log.error(f"Running \"{args.server_binary}\" failed, "
+                          f"set `--server-binary` to a different binary or "
+                          f"set `--system to a container system`")
+                log.info("")
+                log.info(f"The error message was: {e}")
                 return False
 
         # Check if a QLever server is already running on this port.
@@ -200,6 +144,7 @@ class StartCommand(QleverCommand):
             args.cmdline_regex = f"^ServerMain.* -p *{port}"
             log.info("")
             StatusCommand().execute(args)
+
             return False
 
         # Remove already existing container.
@@ -239,13 +184,28 @@ class StartCommand(QleverCommand):
 
         # Set the access token if specified.
         access_arg = f"--data-urlencode \"access-token={args.access_token}\""
-        if (args.description
-        and not setting_index_description(access_arg, port, args.description)):
-            return False
-
-        if (args.text_description
-    and not setting_text_description(access_arg, port, args.text_description)):
-            return False
+        if args.description:
+            desc = args.description
+            curl_cmd = (f"curl -Gs http://localhost:{port}/api"
+                        f" --data-urlencode \"index-description={desc}\""
+                        f" {access_arg} > /dev/null")
+            log.debug(curl_cmd)
+            try:
+                run_command(curl_cmd)
+            except Exception as e:
+                log.error(f"Setting the index description failed ({e})")
+                return False
+        if args.text_description:
+            text_desc = args.text_description
+            curl_cmd = (f"curl -Gs http://localhost:{port}/api"
+                        f" --data-urlencode \"text-description={text_desc}\""
+                        f" {access_arg} > /dev/null")
+            log.debug(curl_cmd)
+            try:
+                run_command(curl_cmd)
+            except Exception as e:
+                log.error(f"Setting the text description failed ({e})")
+                return False
 
         # Kill the tail process. NOTE: `tail_proc.kill()` does not work.
         tail_proc.terminate()

--- a/test/qlever/commands/test_start_execute
+++ b/test/qlever/commands/test_start_execute
@@ -545,7 +545,7 @@ class TestStartCommand(unittest.TestCase):
         mock_run_containerize.return_value = "TestStart2"
 
         # mock StopCommand
-        mock_stop.return_value = None
+        mock_stop.return_value = True
 
         # Mock CacheStatsCommand
         mock_cache_stats_command.return_value = None
@@ -596,4 +596,4 @@ class TestStartCommand(unittest.TestCase):
         mock_construct_cmd_line.return_value = "Test_start_cmd"
 
         # Execute the function and check if return is False
-        self.assertFalse(StartCommand().execute(args))
+        self.assertTrue(StartCommand().execute(args))

--- a/test/qlever/commands/test_start_execute
+++ b/test/qlever/commands/test_start_execute
@@ -167,13 +167,14 @@ class TestStartCommand(unittest.TestCase):
         # Execute the function
         result = sc.execute(args)
 
-        # Assertions
-        mock_run_command.assert_called()  # Ensure the server was started
-        mock_is_qlever_server_alive.assert_called()  # Ensure the server status was checked
-        self.assertTrue(result)  # Execution should succeed
-
         # Check that Popen was called
         mock_popen.assert_called_once_with(f"exec tail -f {args.name}.server-log.txt", shell=True)
 
         # Check warmup was called
         mock_run.assert_called_once_with(args.warmup_cmd, shell=True, check=True)
+        
+        # Assertions
+        mock_is_qlever_server_alive.assert_called()  # Ensure the server status was checked
+        mock_run_command.assert_called()  # Ensure the server was started
+        self.assertTrue(result)  # Execution should succeed
+

--- a/test/qlever/commands/test_start_execute
+++ b/test/qlever/commands/test_start_execute
@@ -19,13 +19,13 @@ class TestStartCommand(unittest.TestCase):
         # Setup args
         args = MagicMock()
         args.kill_existing_with_same_port = True
-        args.port = 8080
+        args.port = 1234
         args.server_binary = "/test/path/server_binary"
         args.name = "TestName"
-        args.num_threads = 4
+        args.num_threads = 2
         args.memory_for_queries = "8G"
         args.cache_max_size = "2G"
-        args.cache_max_size_single_entry = "512M"
+        args.cache_max_size_single_entry = "124M"
         args.cache_max_num_entries = 1000
         args.system = "native"
         args.show = False
@@ -60,15 +60,15 @@ class TestStartCommand(unittest.TestCase):
         # Setup args
         args = MagicMock()
         args.kill_existing_with_same_port = False
-        args.port = 8080
+        args.port = 1234
         args.cmdline_regex = f"^ServerMain.* -p {args.port}"
         args.no_containers = True
         args.server_binary = "/test/path/server_binary"
         args.name = "TestName"
-        args.num_threads = 4
+        args.num_threads = 2
         args.memory_for_queries = "8G"
         args.cache_max_size = "2G"
-        args.cache_max_size_single_entry = "512M"
+        args.cache_max_size_single_entry = "124M"
         args.cache_max_num_entries = 1000
         args.system = "native"
         args.show = False
@@ -101,13 +101,13 @@ class TestStartCommand(unittest.TestCase):
         # Setup args
         args = MagicMock()
         args.kill_existing_with_same_port = False
-        args.port = 8080
+        args.port = 1234
         args.server_binary = "/test/path/server_binary"
         args.name = "TestName"
-        args.num_threads = 4
+        args.num_threads = 2
         args.memory_for_queries = "8G"
         args.cache_max_size = "2G"
-        args.cache_max_size_single_entry = "512M"
+        args.cache_max_size_single_entry = "124M"
         args.cache_max_num_entries = 1000
         args.system = "native"
         args.show = False
@@ -130,26 +130,28 @@ class TestStartCommand(unittest.TestCase):
         self.assertTrue(mock_run_command.called)  # Ensure the server was started
         self.assertTrue(result)  # Ensure execution was successful
 
+    @patch('qlever.commands.start.CacheStatsCommand.execute')
     @patch('qlever.commands.start.run_command')
     @patch('qlever.commands.start.is_qlever_server_alive')
     @patch('subprocess.Popen')
+    @patch('subprocess.run')
     @patch('qlever.commands.start.Containerize')
-    def test_execute_server_with_warmup(self, mock_containerize, mock_popen, mock_is_qlever_server_alive,
-                                        mock_run_command):
+    def test_execute_server_with_warmup(self, mock_containerize, mock_run, mock_popen, mock_is_qlever_server_alive,
+                                        mock_run_command, mock_cache_stats_command):
         # Setup args
         args = MagicMock()
         args.kill_existing_with_same_port = False
-        args.port = 8080
+        args.port = 1234
         args.server_binary = "/test/path/server_binary"
         args.name = "TestName"
-        args.num_threads = 4
+        args.num_threads = 2
         args.memory_for_queries = "8G"
         args.cache_max_size = "2G"
-        args.cache_max_size_single_entry = "512M"
+        args.cache_max_size_single_entry = "124M"
         args.cache_max_num_entries = 1000
         args.system = "native"
         args.show = False
-        args.warmup_cmd = "warmup_command"
+        args.warmup_cmd = "test_warmup_command"
         args.no_warmup = False
 
         # Mock Popen
@@ -157,6 +159,7 @@ class TestStartCommand(unittest.TestCase):
 
         # Mock that no server is currently running
         mock_is_qlever_server_alive.side_effect = [False, True]
+
 
         # Instantiate the StartCommand
         sc = StartCommand()
@@ -169,185 +172,8 @@ class TestStartCommand(unittest.TestCase):
         mock_is_qlever_server_alive.assert_called()  # Ensure the server status was checked
         self.assertTrue(result)  # Execution should succeed
 
-        # Check that Popen was called for tailing the log and warmup, but also check individual calls
-        expected_tail_call = call(f"exec tail -f {args.name}.server-log.txt", shell=True)
-        expected_warmup_call = call(args.warmup_cmd, shell=True)
+        # Check that Popen was called
+        mock_popen.assert_called_once_with(f"exec tail -f {args.name}.server-log.txt", shell=True)
 
-        # Check the individual calls made to Popen
-        mock_popen.assert_has_calls([expected_tail_call, expected_warmup_call], any_order=True)import unittest
-from unittest.mock import patch, MagicMock, call
-from qlever.commands.start import StartCommand
-from qlever.util import run_command, is_qlever_server_alive
-import subprocess
-
-
-class TestStartCommand(unittest.TestCase):
-
-    @patch('qlever.commands.stop.StopCommand.execute', return_value=True)  # Simuliere erfolgreiches Stoppen
-    @patch('qlever.commands.start.run_command')
-    @patch('qlever.commands.start.is_qlever_server_alive')
-    @patch('subprocess.Popen')
-    @patch('qlever.commands.start.Containerize')
-    # @patch('qlever.commands.cache_stats.CacheStatsCommand.execute')
-    # @patch('time.sleep', return_value=None)  # Mocking sleep to avoid delays
-    def test_execute_kills_existing_server_on_same_port(self, mock_containerize, mock_popen,
-                                                        mock_is_qlever_server_alive, mock_run_command, mock_stop):
-        # Setup args
-        args = MagicMock()
-        args.kill_existing_with_same_port = True
-        args.port = 8080
-        args.server_binary = "/test/path/server_binary"
-        args.name = "TestName"
-        args.num_threads = 4
-        args.memory_for_queries = "8G"
-        args.cache_max_size = "2G"
-        args.cache_max_size_single_entry = "512M"
-        args.cache_max_num_entries = 1000
-        args.system = "native"
-        args.show = False
-        args.no_warmup = True
-
-
-        # Mock server is alive initially, then killed, then alive after the restart.
-        # We trust here that the StopCommand to kill the server worked with success.
-        mock_is_qlever_server_alive.side_effect = [False, True]
-
-        # Mock Popen
-        mock_popen.return_value = MagicMock()
-
-        # Instantiate the StartCommand
-        sc = StartCommand()
-
-        # Execute the function
-        result = sc.execute(args)
-
-        # Assertions
-        mock_stop.assert_called_once()  # Ensure the StopCommand was called
-        mock_is_qlever_server_alive.assert_called()  # Server status should be checked
-        self.assertTrue(mock_run_command.called)  # Ensure the server was started
-        self.assertTrue(result)  # Ensure execution was successful
-
-
-    @patch('qlever.commands.start.run_command')
-    @patch('qlever.commands.start.is_qlever_server_alive')
-    @patch('qlever.commands.start.Containerize')
-    def test_execute_fails_due_to_existing_server(self, mock_containerize, mock_is_qlever_server_alive,
-                                                  mock_run_command):
-        # Setup args
-        args = MagicMock()
-        args.kill_existing_with_same_port = False
-        args.port = 8080
-        args.cmdline_regex = f"^ServerMain.* -p {args.port}"
-        args.no_containers = True
-        args.server_binary = "/test/path/server_binary"
-        args.name = "TestName"
-        args.num_threads = 4
-        args.memory_for_queries = "8G"
-        args.cache_max_size = "2G"
-        args.cache_max_size_single_entry = "512M"
-        args.cache_max_num_entries = 1000
-        args.system = "native"
-        args.show = False
-
-        # Mock the QLever server as already running
-        mock_is_qlever_server_alive.return_value = True
-
-        # Instantiate the StartCommand
-        sc = StartCommand()
-
-        # Execute the function
-        result = sc.execute(args)
-
-        # Assertions
-        mock_is_qlever_server_alive.assert_called_once_with(args.port)  # Ensure the server status was checked
-
-        # Check that `run_command` was called only for the `--help` check, but not the actual start command
-        mock_run_command.assert_any_call(f"{args.server_binary} --help")  # Allow the `--help` command
-        self.assertEqual(mock_run_command.call_count, 1,
-                         "run_command should only be called for '--help', not the server start command.")
-        self.assertFalse(result)  # The function should return False if the server is already running
-
-    @patch('qlever.commands.start.run_command')
-    @patch('qlever.commands.start.is_qlever_server_alive')
-    @patch('subprocess.Popen')
-    @patch('qlever.commands.start.Containerize')
-    @patch('time.sleep', return_value=None)  # Mocking sleep to avoid delays
-    def test_execute_successful_server_start(self, mock_sleep, mock_containerize, mock_popen,
-                                             mock_is_qlever_server_alive, mock_run_command):
-        # Setup args
-        args = MagicMock()
-        args.kill_existing_with_same_port = False
-        args.port = 8080
-        args.server_binary = "/test/path/server_binary"
-        args.name = "TestName"
-        args.num_threads = 4
-        args.memory_for_queries = "8G"
-        args.cache_max_size = "2G"
-        args.cache_max_size_single_entry = "512M"
-        args.cache_max_num_entries = 1000
-        args.system = "native"
-        args.show = False
-        args.no_warmup = True
-
-        # Mock server is not alive initially, then alive after starting
-        mock_is_qlever_server_alive.side_effect = [False, True]
-
-        # Mock Popen
-        mock_popen.return_value = MagicMock()
-
-        # Instantiate the StartCommand
-        sc = StartCommand()
-
-        # Execute the function
-        result = sc.execute(args)
-
-        # Assertions
-        mock_is_qlever_server_alive.assert_called()  # Server status should be checked
-        self.assertTrue(mock_run_command.called)  # Ensure the server was started
-        self.assertTrue(result)  # Ensure execution was successful
-
-    @patch('qlever.commands.start.run_command')
-    @patch('qlever.commands.start.is_qlever_server_alive')
-    @patch('subprocess.Popen')
-    @patch('qlever.commands.start.Containerize')
-    def test_execute_server_with_warmup(self, mock_containerize, mock_popen, mock_is_qlever_server_alive,
-                                        mock_run_command):
-        # Setup args
-        args = MagicMock()
-        args.kill_existing_with_same_port = False
-        args.port = 8080
-        args.server_binary = "/test/path/server_binary"
-        args.name = "TestName"
-        args.num_threads = 4
-        args.memory_for_queries = "8G"
-        args.cache_max_size = "2G"
-        args.cache_max_size_single_entry = "512M"
-        args.cache_max_num_entries = 1000
-        args.system = "native"
-        args.show = False
-        args.warmup_cmd = "warmup_command"
-        args.no_warmup = False
-
-        # Mock Popen
-        mock_popen.return_value = MagicMock()
-
-        # Mock that no server is currently running
-        mock_is_qlever_server_alive.side_effect = [False, True]
-
-        # Instantiate the StartCommand
-        sc = StartCommand()
-
-        # Execute the function
-        result = sc.execute(args)
-
-        # Assertions
-        mock_run_command.assert_called()  # Ensure the server was started
-        mock_is_qlever_server_alive.assert_called()  # Ensure the server status was checked
-        self.assertTrue(result)  # Execution should succeed
-
-        # Check that Popen was called for tailing the log and warmup, but also check individual calls
-        expected_tail_call = call(f"exec tail -f {args.name}.server-log.txt", shell=True)
-        expected_warmup_call = call(args.warmup_cmd, shell=True)
-
-        # Check the individual calls made to Popen
-        mock_popen.assert_has_calls([expected_tail_call, expected_warmup_call], any_order=True)
+        # Check warmup was called
+        mock_run.assert_called_once_with(args.warmup_cmd, shell=True, check=True)

--- a/test/qlever/commands/test_start_execute
+++ b/test/qlever/commands/test_start_execute
@@ -1,6 +1,78 @@
 import unittest
 from unittest.mock import patch, MagicMock, call
 from qlever.commands.start import StartCommand
+import qlever.commands.start
+
+
+# Tests if the construction of the command line works if every "if" is taken
+def test_construct_command_line_with_if():
+    # Setup args
+    args = MagicMock()
+    args.server_binary = "/test/path/server_binary"
+    args.name = "TestName"
+    args.num_threads = 2
+    args.port = 1234
+    args.memory_for_queries = "8G"
+    args.cache_max_size = "2G"
+    args.cache_max_size_single_entry = "124M"
+    args.cache_max_num_entries = 1000
+    args.timeout = True
+    args.access_token = True
+    args.only_pso_and_pos_permutations = True
+    args.use_patterns = False
+    args.use_text_index = "yes"
+
+    # Execute the function
+    result = qlever.commands.start.construct_command_line(args)
+
+    start_command = (f"{args.server_binary}"
+                     f" -i {args.name}"
+                     f" -j {args.num_threads}"
+                     f" -p {args.port}"
+                     f" -m {args.memory_for_queries}"
+                     f" -c {args.cache_max_size}"
+                     f" -e {args.cache_max_size_single_entry}"
+                     f" -k {args.cache_max_num_entries}"
+                     f" -s {args.timeout}"
+                     f" -a {args.access_token}"
+                     " --only-pso-and-pos-permutations"
+                     " --no-patterns"
+                     " -t"
+                     f" > {args.name}.server-log.txt 2>&1")
+    assert result == start_command
+
+
+# Tests if the construction of the command line works if no "if" is taken
+def test_construct_command_line_without_if():
+    # Setup args
+    args = MagicMock()
+    args.server_binary = "/test/path/server_binary"
+    args.name = "TestName"
+    args.num_threads = 2
+    args.port = 1234
+    args.memory_for_queries = "8G"
+    args.cache_max_size = "2G"
+    args.cache_max_size_single_entry = "124M"
+    args.cache_max_num_entries = 1000
+    args.timeout = False
+    args.access_token = False
+    args.only_pso_and_pos_permutations = False
+    args.use_patterns = True
+    args.use_text_index = "no"
+
+    # Execute the function
+    result = qlever.commands.start.construct_command_line(args)
+
+    start_command = (f"{args.server_binary}"
+                     f" -i {args.name}"
+                     f" -j {args.num_threads}"
+                     f" -p {args.port}"
+                     f" -m {args.memory_for_queries}"
+                     f" -c {args.cache_max_size}"
+                     f" -e {args.cache_max_size_single_entry}"
+                     f" -k {args.cache_max_num_entries}"
+                     f" > {args.name}.server-log.txt 2>&1")
+    assert result == start_command
 
 
 class TestStartCommand(unittest.TestCase):
@@ -251,8 +323,6 @@ class TestStartCommand(unittest.TestCase):
     @patch('qlever.commands.start.Containerize.supported_systems')
     @patch('qlever.commands.start.run_command_in_container')
     @patch('qlever.commands.start.construct_command_line')
-    # This test just works with other start execute bc current one doesn't
-    # have run_command_in_container and construct_command_line
     def test_execute_containerize_and_description(self,
                                 mock_construct_cl, mock_run_containerize,
                                 mock_containerize, mock_popen,

--- a/test/qlever/commands/test_start_execute
+++ b/test/qlever/commands/test_start_execute
@@ -251,6 +251,8 @@ class TestStartCommand(unittest.TestCase):
     @patch('qlever.commands.start.Containerize.supported_systems')
     @patch('qlever.commands.start.run_command_in_container')
     @patch('qlever.commands.start.construct_command_line')
+    # This test just works with other start execute bc current one doesn't
+    # have run_command_in_container and construct_command_line
     def test_execute_containerize_and_description(self,
                                 mock_construct_cl, mock_run_containerize,
                                 mock_containerize, mock_popen,

--- a/test/qlever/commands/test_start_execute
+++ b/test/qlever/commands/test_start_execute
@@ -1,0 +1,353 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+from qlever.commands.start import StartCommand
+from qlever.util import run_command, is_qlever_server_alive
+import subprocess
+
+
+class TestStartCommand(unittest.TestCase):
+
+    @patch('qlever.commands.stop.StopCommand.execute', return_value=True)  # Simuliere erfolgreiches Stoppen
+    @patch('qlever.commands.start.run_command')
+    @patch('qlever.commands.start.is_qlever_server_alive')
+    @patch('subprocess.Popen')
+    @patch('qlever.commands.start.Containerize')
+    # @patch('qlever.commands.cache_stats.CacheStatsCommand.execute')
+    # @patch('time.sleep', return_value=None)  # Mocking sleep to avoid delays
+    def test_execute_kills_existing_server_on_same_port(self, mock_containerize, mock_popen,
+                                                        mock_is_qlever_server_alive, mock_run_command, mock_stop):
+        # Setup args
+        args = MagicMock()
+        args.kill_existing_with_same_port = True
+        args.port = 8080
+        args.server_binary = "/test/path/server_binary"
+        args.name = "TestName"
+        args.num_threads = 4
+        args.memory_for_queries = "8G"
+        args.cache_max_size = "2G"
+        args.cache_max_size_single_entry = "512M"
+        args.cache_max_num_entries = 1000
+        args.system = "native"
+        args.show = False
+        args.no_warmup = True
+
+
+        # Mock server is alive initially, then killed, then alive after the restart.
+        # We trust here that the StopCommand to kill the server worked with success.
+        mock_is_qlever_server_alive.side_effect = [False, True]
+
+        # Mock Popen
+        mock_popen.return_value = MagicMock()
+
+        # Instantiate the StartCommand
+        sc = StartCommand()
+
+        # Execute the function
+        result = sc.execute(args)
+
+        # Assertions
+        mock_stop.assert_called_once()  # Ensure the StopCommand was called
+        mock_is_qlever_server_alive.assert_called()  # Server status should be checked
+        self.assertTrue(mock_run_command.called)  # Ensure the server was started
+        self.assertTrue(result)  # Ensure execution was successful
+
+
+    @patch('qlever.commands.start.run_command')
+    @patch('qlever.commands.start.is_qlever_server_alive')
+    @patch('qlever.commands.start.Containerize')
+    def test_execute_fails_due_to_existing_server(self, mock_containerize, mock_is_qlever_server_alive,
+                                                  mock_run_command):
+        # Setup args
+        args = MagicMock()
+        args.kill_existing_with_same_port = False
+        args.port = 8080
+        args.cmdline_regex = f"^ServerMain.* -p {args.port}"
+        args.no_containers = True
+        args.server_binary = "/test/path/server_binary"
+        args.name = "TestName"
+        args.num_threads = 4
+        args.memory_for_queries = "8G"
+        args.cache_max_size = "2G"
+        args.cache_max_size_single_entry = "512M"
+        args.cache_max_num_entries = 1000
+        args.system = "native"
+        args.show = False
+
+        # Mock the QLever server as already running
+        mock_is_qlever_server_alive.return_value = True
+
+        # Instantiate the StartCommand
+        sc = StartCommand()
+
+        # Execute the function
+        result = sc.execute(args)
+
+        # Assertions
+        mock_is_qlever_server_alive.assert_called_once_with(args.port)  # Ensure the server status was checked
+
+        # Check that `run_command` was called only for the `--help` check, but not the actual start command
+        mock_run_command.assert_any_call(f"{args.server_binary} --help")  # Allow the `--help` command
+        self.assertEqual(mock_run_command.call_count, 1,
+                         "run_command should only be called for '--help', not the server start command.")
+        self.assertFalse(result)  # The function should return False if the server is already running
+
+    @patch('qlever.commands.start.run_command')
+    @patch('qlever.commands.start.is_qlever_server_alive')
+    @patch('subprocess.Popen')
+    @patch('qlever.commands.start.Containerize')
+    @patch('time.sleep', return_value=None)  # Mocking sleep to avoid delays
+    def test_execute_successful_server_start(self, mock_sleep, mock_containerize, mock_popen,
+                                             mock_is_qlever_server_alive, mock_run_command):
+        # Setup args
+        args = MagicMock()
+        args.kill_existing_with_same_port = False
+        args.port = 8080
+        args.server_binary = "/test/path/server_binary"
+        args.name = "TestName"
+        args.num_threads = 4
+        args.memory_for_queries = "8G"
+        args.cache_max_size = "2G"
+        args.cache_max_size_single_entry = "512M"
+        args.cache_max_num_entries = 1000
+        args.system = "native"
+        args.show = False
+        args.no_warmup = True
+
+        # Mock server is not alive initially, then alive after starting
+        mock_is_qlever_server_alive.side_effect = [False, True]
+
+        # Mock Popen
+        mock_popen.return_value = MagicMock()
+
+        # Instantiate the StartCommand
+        sc = StartCommand()
+
+        # Execute the function
+        result = sc.execute(args)
+
+        # Assertions
+        mock_is_qlever_server_alive.assert_called()  # Server status should be checked
+        self.assertTrue(mock_run_command.called)  # Ensure the server was started
+        self.assertTrue(result)  # Ensure execution was successful
+
+    @patch('qlever.commands.start.run_command')
+    @patch('qlever.commands.start.is_qlever_server_alive')
+    @patch('subprocess.Popen')
+    @patch('qlever.commands.start.Containerize')
+    def test_execute_server_with_warmup(self, mock_containerize, mock_popen, mock_is_qlever_server_alive,
+                                        mock_run_command):
+        # Setup args
+        args = MagicMock()
+        args.kill_existing_with_same_port = False
+        args.port = 8080
+        args.server_binary = "/test/path/server_binary"
+        args.name = "TestName"
+        args.num_threads = 4
+        args.memory_for_queries = "8G"
+        args.cache_max_size = "2G"
+        args.cache_max_size_single_entry = "512M"
+        args.cache_max_num_entries = 1000
+        args.system = "native"
+        args.show = False
+        args.warmup_cmd = "warmup_command"
+        args.no_warmup = False
+
+        # Mock Popen
+        mock_popen.return_value = MagicMock()
+
+        # Mock that no server is currently running
+        mock_is_qlever_server_alive.side_effect = [False, True]
+
+        # Instantiate the StartCommand
+        sc = StartCommand()
+
+        # Execute the function
+        result = sc.execute(args)
+
+        # Assertions
+        mock_run_command.assert_called()  # Ensure the server was started
+        mock_is_qlever_server_alive.assert_called()  # Ensure the server status was checked
+        self.assertTrue(result)  # Execution should succeed
+
+        # Check that Popen was called for tailing the log and warmup, but also check individual calls
+        expected_tail_call = call(f"exec tail -f {args.name}.server-log.txt", shell=True)
+        expected_warmup_call = call(args.warmup_cmd, shell=True)
+
+        # Check the individual calls made to Popen
+        mock_popen.assert_has_calls([expected_tail_call, expected_warmup_call], any_order=True)import unittest
+from unittest.mock import patch, MagicMock, call
+from qlever.commands.start import StartCommand
+from qlever.util import run_command, is_qlever_server_alive
+import subprocess
+
+
+class TestStartCommand(unittest.TestCase):
+
+    @patch('qlever.commands.stop.StopCommand.execute', return_value=True)  # Simuliere erfolgreiches Stoppen
+    @patch('qlever.commands.start.run_command')
+    @patch('qlever.commands.start.is_qlever_server_alive')
+    @patch('subprocess.Popen')
+    @patch('qlever.commands.start.Containerize')
+    # @patch('qlever.commands.cache_stats.CacheStatsCommand.execute')
+    # @patch('time.sleep', return_value=None)  # Mocking sleep to avoid delays
+    def test_execute_kills_existing_server_on_same_port(self, mock_containerize, mock_popen,
+                                                        mock_is_qlever_server_alive, mock_run_command, mock_stop):
+        # Setup args
+        args = MagicMock()
+        args.kill_existing_with_same_port = True
+        args.port = 8080
+        args.server_binary = "/test/path/server_binary"
+        args.name = "TestName"
+        args.num_threads = 4
+        args.memory_for_queries = "8G"
+        args.cache_max_size = "2G"
+        args.cache_max_size_single_entry = "512M"
+        args.cache_max_num_entries = 1000
+        args.system = "native"
+        args.show = False
+        args.no_warmup = True
+
+
+        # Mock server is alive initially, then killed, then alive after the restart.
+        # We trust here that the StopCommand to kill the server worked with success.
+        mock_is_qlever_server_alive.side_effect = [False, True]
+
+        # Mock Popen
+        mock_popen.return_value = MagicMock()
+
+        # Instantiate the StartCommand
+        sc = StartCommand()
+
+        # Execute the function
+        result = sc.execute(args)
+
+        # Assertions
+        mock_stop.assert_called_once()  # Ensure the StopCommand was called
+        mock_is_qlever_server_alive.assert_called()  # Server status should be checked
+        self.assertTrue(mock_run_command.called)  # Ensure the server was started
+        self.assertTrue(result)  # Ensure execution was successful
+
+
+    @patch('qlever.commands.start.run_command')
+    @patch('qlever.commands.start.is_qlever_server_alive')
+    @patch('qlever.commands.start.Containerize')
+    def test_execute_fails_due_to_existing_server(self, mock_containerize, mock_is_qlever_server_alive,
+                                                  mock_run_command):
+        # Setup args
+        args = MagicMock()
+        args.kill_existing_with_same_port = False
+        args.port = 8080
+        args.cmdline_regex = f"^ServerMain.* -p {args.port}"
+        args.no_containers = True
+        args.server_binary = "/test/path/server_binary"
+        args.name = "TestName"
+        args.num_threads = 4
+        args.memory_for_queries = "8G"
+        args.cache_max_size = "2G"
+        args.cache_max_size_single_entry = "512M"
+        args.cache_max_num_entries = 1000
+        args.system = "native"
+        args.show = False
+
+        # Mock the QLever server as already running
+        mock_is_qlever_server_alive.return_value = True
+
+        # Instantiate the StartCommand
+        sc = StartCommand()
+
+        # Execute the function
+        result = sc.execute(args)
+
+        # Assertions
+        mock_is_qlever_server_alive.assert_called_once_with(args.port)  # Ensure the server status was checked
+
+        # Check that `run_command` was called only for the `--help` check, but not the actual start command
+        mock_run_command.assert_any_call(f"{args.server_binary} --help")  # Allow the `--help` command
+        self.assertEqual(mock_run_command.call_count, 1,
+                         "run_command should only be called for '--help', not the server start command.")
+        self.assertFalse(result)  # The function should return False if the server is already running
+
+    @patch('qlever.commands.start.run_command')
+    @patch('qlever.commands.start.is_qlever_server_alive')
+    @patch('subprocess.Popen')
+    @patch('qlever.commands.start.Containerize')
+    @patch('time.sleep', return_value=None)  # Mocking sleep to avoid delays
+    def test_execute_successful_server_start(self, mock_sleep, mock_containerize, mock_popen,
+                                             mock_is_qlever_server_alive, mock_run_command):
+        # Setup args
+        args = MagicMock()
+        args.kill_existing_with_same_port = False
+        args.port = 8080
+        args.server_binary = "/test/path/server_binary"
+        args.name = "TestName"
+        args.num_threads = 4
+        args.memory_for_queries = "8G"
+        args.cache_max_size = "2G"
+        args.cache_max_size_single_entry = "512M"
+        args.cache_max_num_entries = 1000
+        args.system = "native"
+        args.show = False
+        args.no_warmup = True
+
+        # Mock server is not alive initially, then alive after starting
+        mock_is_qlever_server_alive.side_effect = [False, True]
+
+        # Mock Popen
+        mock_popen.return_value = MagicMock()
+
+        # Instantiate the StartCommand
+        sc = StartCommand()
+
+        # Execute the function
+        result = sc.execute(args)
+
+        # Assertions
+        mock_is_qlever_server_alive.assert_called()  # Server status should be checked
+        self.assertTrue(mock_run_command.called)  # Ensure the server was started
+        self.assertTrue(result)  # Ensure execution was successful
+
+    @patch('qlever.commands.start.run_command')
+    @patch('qlever.commands.start.is_qlever_server_alive')
+    @patch('subprocess.Popen')
+    @patch('qlever.commands.start.Containerize')
+    def test_execute_server_with_warmup(self, mock_containerize, mock_popen, mock_is_qlever_server_alive,
+                                        mock_run_command):
+        # Setup args
+        args = MagicMock()
+        args.kill_existing_with_same_port = False
+        args.port = 8080
+        args.server_binary = "/test/path/server_binary"
+        args.name = "TestName"
+        args.num_threads = 4
+        args.memory_for_queries = "8G"
+        args.cache_max_size = "2G"
+        args.cache_max_size_single_entry = "512M"
+        args.cache_max_num_entries = 1000
+        args.system = "native"
+        args.show = False
+        args.warmup_cmd = "warmup_command"
+        args.no_warmup = False
+
+        # Mock Popen
+        mock_popen.return_value = MagicMock()
+
+        # Mock that no server is currently running
+        mock_is_qlever_server_alive.side_effect = [False, True]
+
+        # Instantiate the StartCommand
+        sc = StartCommand()
+
+        # Execute the function
+        result = sc.execute(args)
+
+        # Assertions
+        mock_run_command.assert_called()  # Ensure the server was started
+        mock_is_qlever_server_alive.assert_called()  # Ensure the server status was checked
+        self.assertTrue(result)  # Execution should succeed
+
+        # Check that Popen was called for tailing the log and warmup, but also check individual calls
+        expected_tail_call = call(f"exec tail -f {args.name}.server-log.txt", shell=True)
+        expected_warmup_call = call(args.warmup_cmd, shell=True)
+
+        # Check the individual calls made to Popen
+        mock_popen.assert_has_calls([expected_tail_call, expected_warmup_call], any_order=True)

--- a/test/qlever/commands/test_start_execute
+++ b/test/qlever/commands/test_start_execute
@@ -7,6 +7,7 @@ import subprocess
 
 class TestStartCommand(unittest.TestCase):
 
+    @patch('qlever.commands.start.CacheStatsCommand.execute')
     @patch('qlever.commands.stop.StopCommand.execute', return_value=True)  # Simuliere erfolgreiches Stoppen
     @patch('qlever.commands.start.run_command')
     @patch('qlever.commands.start.is_qlever_server_alive')
@@ -15,7 +16,7 @@ class TestStartCommand(unittest.TestCase):
     # @patch('qlever.commands.cache_stats.CacheStatsCommand.execute')
     # @patch('time.sleep', return_value=None)  # Mocking sleep to avoid delays
     def test_execute_kills_existing_server_on_same_port(self, mock_containerize, mock_popen,
-                                                        mock_is_qlever_server_alive, mock_run_command, mock_stop):
+                                                        mock_is_qlever_server_alive, mock_run_command, mock_stop, mock_cache_stats_command):
         # Setup args
         args = MagicMock()
         args.kill_existing_with_same_port = True
@@ -91,13 +92,14 @@ class TestStartCommand(unittest.TestCase):
                          "run_command should only be called for '--help', not the server start command.")
         self.assertFalse(result)  # The function should return False if the server is already running
 
+    @patch('qlever.commands.start.CacheStatsCommand.execute')
     @patch('qlever.commands.start.run_command')
     @patch('qlever.commands.start.is_qlever_server_alive')
     @patch('subprocess.Popen')
     @patch('qlever.commands.start.Containerize')
     @patch('time.sleep', return_value=None)  # Mocking sleep to avoid delays
     def test_execute_successful_server_start(self, mock_sleep, mock_containerize, mock_popen,
-                                             mock_is_qlever_server_alive, mock_run_command):
+                                             mock_is_qlever_server_alive, mock_run_command, mock_cache_stats_command):
         # Setup args
         args = MagicMock()
         args.kill_existing_with_same_port = False
@@ -172,9 +174,8 @@ class TestStartCommand(unittest.TestCase):
 
         # Check warmup was called
         mock_run.assert_called_once_with(args.warmup_cmd, shell=True, check=True)
-        
+
         # Assertions
         mock_is_qlever_server_alive.assert_called()  # Ensure the server status was checked
         mock_run_command.assert_called()  # Ensure the server was started
         self.assertTrue(result)  # Execution should succeed
-

--- a/test/qlever/commands/test_start_execute
+++ b/test/qlever/commands/test_start_execute
@@ -74,6 +74,193 @@ def test_construct_command_line_without_if():
                      f" > {args.name}.server-log.txt 2>&1")
     assert result == start_command
 
+# Tests the run_command_in_container help function while mocking
+# containerize_command.
+@patch('qlever.commands.start.Containerize.containerize_command')
+def test_run_command_in_container(mock_containerize):
+    # Setup args
+    args = MagicMock()
+    args.name = "TestName"
+    args.server_container = f"qlever.server.{args.name}"
+    args.port = 1234
+    args.system = "native"
+    args.image = None
+
+    #Mock containerize_command
+    mock_containerize.return_value = "Test_Container_Command"
+
+    # start_cmd before construct_command_line(args)
+    start_cmd = "Test_start_cmd"
+    # Execute the function
+    result = qlever.commands.start.run_command_in_container(args, start_cmd)
+
+    # check containerize_command was called once with correct parameters
+    mock_containerize.assert_called_once_with(start_cmd, args.system,
+        "run -d --restart=unless-stopped", args.image, args.server_container,
+        volumes=[("$(pwd)", "/index")], ports=[(args.port, args.port)],
+        working_directory="/index")
+    # check start command was successfully returned
+    start_command = "Test_Container_Command"
+    assert result == start_command
+
+
+# Tests the check_binary help function for the case of success of the
+# run_cmd in the try/except block
+@patch('qlever.commands.start.run_command')
+def test_check_binary_success(mock_run_cmd):
+    # Setup args
+    args = MagicMock()
+    args.server_binary = "/test/path/server_binary"
+    # mock run_cmd as successful
+    mock_run_cmd.return_value = "Command works"
+
+    # Execute the function
+    result = qlever.commands.start.check_binary(args.server_binary)
+    # check if run_cmd was called once with
+    mock_run_cmd.assert_called_once_with(f"{args.server_binary} --help")
+    assert result
+
+
+# Tests the check_binary help function for the case of exception for the
+# run_cmd in the try/except block
+@patch('qlever.commands.start.run_command')
+@patch('qlever.commands.start.log')
+def test_check_binary_exception(mock_log, mock_run_cmd):
+    # Setup args
+    args = MagicMock()
+    args.server_binary = "false_binary"
+
+    # Simulate an exception when run_command is called
+    mock_run_cmd.side_effect = Exception("Mocked command failure")
+
+    # Execute the function
+    result = qlever.commands.start.check_binary(args.server_binary)
+
+    # check if run_cmd was called once with
+    mock_run_cmd.assert_called_once_with(f"{args.server_binary} --help")
+    # Verify that the error message was logged
+    mock_log.error.assert_called_once_with(
+        'Running "false_binary" failed, set `--server-binary` to a different'
+        ' binary or set `--system to a container system`')
+    # Check that the info log contains the exception message
+    mock_log.info.assert_any_call(
+        'The error message was: Mocked command failure')
+    assert not result
+
+
+# Tests the setting_index_description help function for the case of success
+# of the run_cmd in the try/except block
+@patch('qlever.commands.start.run_command')
+@patch('qlever.commands.start.log')
+def test_setting_index_description_success(mock_log, mock_run_cmd):
+    # Setup args
+    args = MagicMock()
+    args.access_token = True
+    args.port = 1234
+    args.description = "TestDescription"
+    access_arg = f"--data-urlencode \"access-token={args.access_token}\""
+
+    # Execute the function
+    qlever.commands.start.setting_index_description(access_arg, args.port,
+                                                        args.description)
+    # Asserts
+    curl_cmd = (f"curl -Gs http://localhost:{args.port}/api"
+                f" --data-urlencode \"index-description={args.description}\""
+                f" {access_arg} > /dev/null")
+    # Verify that the debug message was logged
+    mock_log.debug.assert_called_once_with(curl_cmd)
+    # check if run_cmd was called once with correct parameters
+    mock_run_cmd.assert_called_once_with(curl_cmd)
+
+
+# Tests the setting_index_description help function for the case of exception
+# for the run_cmd in the try/except block
+@patch('qlever.commands.start.run_command')
+@patch('qlever.commands.start.log')
+def test_setting_index_description_exception(mock_log, mock_run_cmd):
+    # Setup args
+    args = MagicMock()
+    args.access_token = True
+    args.port = 1234
+    args.description = "ErrorDescription"
+    access_arg = f"--data-urlencode \"access-token={args.access_token}\""
+
+    # Simulate an exception when run_command is called
+    mock_run_cmd.side_effect = Exception("Mocked command failure")
+
+    # Execute the function
+    qlever.commands.start.setting_index_description(access_arg, args.port,
+                                                        args.description)
+
+    # Asserts
+    curl_cmd = (f"curl -Gs http://localhost:{args.port}/api"
+                f" --data-urlencode \"index-description={args.description}\""
+                f" {access_arg} > /dev/null")
+    # Verify that the debug message was logged
+    mock_log.debug.assert_called_once_with(curl_cmd)
+    # check if run_cmd was called once with correct parameters
+    mock_run_cmd.assert_called_once_with(curl_cmd)
+    # Verify that the error message was logged
+    mock_log.error.assert_called_once_with(
+        f"Setting the index description failed (Mocked command failure)")
+
+
+# Tests the setting_text_description help function for the case of success
+# of the run_cmd in the try/except block
+@patch('qlever.commands.start.run_command')
+@patch('qlever.commands.start.log')
+def test_setting_text_description_success(mock_log, mock_run_cmd):
+    # Setup args
+    args = MagicMock()
+    args.access_token = True
+    args.port = 1234
+    args.description = "TestDescription"
+    access_arg = f"--data-urlencode \"access-token={args.access_token}\""
+
+    # Execute the function
+    qlever.commands.start.setting_text_description(access_arg, args.port,
+                                                        args.description)
+    # Asserts
+    curl_cmd = (f"curl -Gs http://localhost:{args.port}/api"
+                f" --data-urlencode \"text-description={args.description}\""
+                f" {access_arg} > /dev/null")
+    # Verify that the debug message was logged
+    mock_log.debug.assert_called_once_with(curl_cmd)
+    # check if run_cmd was called once with correct parameters
+    mock_run_cmd.assert_called_once_with(curl_cmd)
+
+
+# Tests the setting_text_description help function for the case of exception
+# for the run_cmd in the try/except block
+@patch('qlever.commands.start.run_command')
+@patch('qlever.commands.start.log')
+def test_setting_text_description_exception(mock_log, mock_run_cmd):
+    # Setup args
+    args = MagicMock()
+    args.access_token = True
+    args.port = 1234
+    args.description = "ErrorDescription"
+    access_arg = f"--data-urlencode \"access-token={args.access_token}\""
+
+    # Simulate an exception when run_command is called
+    mock_run_cmd.side_effect = Exception("Mocked command failure")
+
+    # Execute the function
+    qlever.commands.start.setting_text_description(access_arg, args.port,
+                                                        args.description)
+
+    # Asserts
+    curl_cmd = (f"curl -Gs http://localhost:{args.port}/api"
+                f" --data-urlencode \"text-description={args.description}\""
+                f" {access_arg} > /dev/null")
+    # Verify that the debug message was logged
+    mock_log.debug.assert_called_once_with(curl_cmd)
+    # check if run_cmd was called once with correct parameters
+    mock_run_cmd.assert_called_once_with(curl_cmd)
+    # Verify that the error message was logged
+    mock_log.error.assert_called_once_with(
+        f"Setting the text description failed (Mocked command failure)")
+
 
 class TestStartCommand(unittest.TestCase):
 
@@ -396,3 +583,17 @@ class TestStartCommand(unittest.TestCase):
         mock_is_qlever_server_alive.assert_called()
         # Ensure execution was successful
         self.assertTrue(result)
+
+    # check if execute returns False for args.show = True
+    @patch('qlever.commands.start.construct_command_line')
+    def test_execute_show(self, mock_construct_cmd_line):
+        # Setup args
+        args = MagicMock()
+        args.kill_existing_with_same_port = False
+        args.system = None
+        args.show = True
+        # Mock construct_command_line
+        mock_construct_cmd_line.return_value = "Test_start_cmd"
+
+        # Execute the function and check if return is False
+        self.assertFalse(StartCommand().execute(args))

--- a/test/qlever/commands/test_start_execute
+++ b/test/qlever/commands/test_start_execute
@@ -1,22 +1,22 @@
 import unittest
 from unittest.mock import patch, MagicMock, call
 from qlever.commands.start import StartCommand
-from qlever.util import run_command, is_qlever_server_alive
-import subprocess
 
 
 class TestStartCommand(unittest.TestCase):
 
     @patch('qlever.commands.start.CacheStatsCommand.execute')
-    @patch('qlever.commands.stop.StopCommand.execute', return_value=True)  # Simuliere erfolgreiches Stoppen
+    @patch('qlever.commands.stop.StopCommand.execute', return_value=True)
     @patch('qlever.commands.start.run_command')
     @patch('qlever.commands.start.is_qlever_server_alive')
     @patch('subprocess.Popen')
     @patch('qlever.commands.start.Containerize')
-    # @patch('qlever.commands.cache_stats.CacheStatsCommand.execute')
-    # @patch('time.sleep', return_value=None)  # Mocking sleep to avoid delays
-    def test_execute_kills_existing_server_on_same_port(self, mock_containerize, mock_popen,
-                                                        mock_is_qlever_server_alive, mock_run_command, mock_stop, mock_cache_stats_command):
+    # Tests if killing existing server and restarting a new one works.
+    # Also checks the start_command for all the extra options enabled.
+    def test_execute_kills_existing_server_on_same_port(self,
+                                mock_containerize, mock_popen,
+                                mock_is_qlever_server_alive, mock_run_command,
+                                mock_stop, mock_cache_stats_command):
         # Setup args
         args = MagicMock()
         args.kill_existing_with_same_port = True
@@ -31,10 +31,19 @@ class TestStartCommand(unittest.TestCase):
         args.system = "native"
         args.show = False
         args.no_warmup = True
+        args.timeout = True
+        args.access_token = True
+        args.only_pso_and_pos_permutations = True
+        args.use_patterns = False
+        args.use_text_index = "yes"
 
+        # Mock CacheStatsCommand
+        mock_cache_stats_command.return_value = None
 
-        # Mock server is alive initially, then killed, then alive after the restart.
-        # We trust here that the StopCommand to kill the server worked with success.
+        # Mock Containerize
+        mock_containerize.return_value = None
+
+        # Mock server is not alive initially, then alive after starting
         mock_is_qlever_server_alive.side_effect = [False, True]
 
         # Mock Popen
@@ -47,16 +56,41 @@ class TestStartCommand(unittest.TestCase):
         result = sc.execute(args)
 
         # Assertions
-        mock_stop.assert_called_once()  # Ensure the StopCommand was called
-        mock_is_qlever_server_alive.assert_called()  # Server status should be checked
-        self.assertTrue(mock_run_command.called)  # Ensure the server was started
-        self.assertTrue(result)  # Ensure execution was successful
+        # Ensure the StopCommand was called
+        mock_stop.assert_called_once()
+        # Server status should be checked
+        mock_is_qlever_server_alive.assert_called()
+
+        # Ensure the server was started
+        run_call_1 = f"{args.server_binary} --help"
+        start_command = (f"{args.server_binary}"
+                        f" -i {args.name}"
+                        f" -j {args.num_threads}"
+                        f" -p {args.port}"
+                        f" -m {args.memory_for_queries}"
+                        f" -c {args.cache_max_size}"
+                        f" -e {args.cache_max_size_single_entry}"
+                        f" -k {args.cache_max_num_entries}"
+                        f" -s {args.timeout}"
+                        f" -a {args.access_token}"
+                        " --only-pso-and-pos-permutations"
+                        " --no-patterns"
+                        " -t"
+                        f" > {args.name}.server-log.txt 2>&1")
+        run_call_2 = f"nohup {start_command} &"
+        # Assert that run_command was called exactly twice with the
+        # correct arguments in order
+        mock_run_command.assert_has_calls([call(run_call_1), call(run_call_2)],
+                                          any_order=False)
+        # Ensure execution was successful
+        self.assertTrue(result)
 
 
     @patch('qlever.commands.start.run_command')
     @patch('qlever.commands.start.is_qlever_server_alive')
     @patch('qlever.commands.start.Containerize')
-    def test_execute_fails_due_to_existing_server(self, mock_containerize, mock_is_qlever_server_alive,
+    def test_execute_fails_due_to_existing_server(self, mock_containerize,
+                                                  mock_is_qlever_server_alive,
                                                   mock_run_command):
         # Setup args
         args = MagicMock()
@@ -77,6 +111,9 @@ class TestStartCommand(unittest.TestCase):
         # Mock the QLever server as already running
         mock_is_qlever_server_alive.return_value = True
 
+        # Mock Containerize
+        mock_containerize.return_value = None
+
         # Instantiate the StartCommand
         sc = StartCommand()
 
@@ -84,22 +121,25 @@ class TestStartCommand(unittest.TestCase):
         result = sc.execute(args)
 
         # Assertions
-        mock_is_qlever_server_alive.assert_called_once_with(args.port)  # Ensure the server status was checked
-
-        # Check that `run_command` was called only for the `--help` check, but not the actual start command
-        mock_run_command.assert_any_call(f"{args.server_binary} --help")  # Allow the `--help` command
-        self.assertEqual(mock_run_command.call_count, 1,
-                         "run_command should only be called for '--help', not the server start command.")
-        self.assertFalse(result)  # The function should return False if the server is already running
+        # Ensure the server status was checked
+        mock_is_qlever_server_alive.assert_called_once_with(args.port)
+        # Check that `run_command` was called only for the `--help` check,
+        # but not the actual start command
+        mock_run_command.assert_called_once_with(
+                                                f"{args.server_binary} --help")
+        # The function should return False if the server is already running
+        self.assertFalse(result)
 
     @patch('qlever.commands.start.CacheStatsCommand.execute')
     @patch('qlever.commands.start.run_command')
     @patch('qlever.commands.start.is_qlever_server_alive')
     @patch('subprocess.Popen')
     @patch('qlever.commands.start.Containerize')
-    @patch('time.sleep', return_value=None)  # Mocking sleep to avoid delays
-    def test_execute_successful_server_start(self, mock_sleep, mock_containerize, mock_popen,
-                                             mock_is_qlever_server_alive, mock_run_command, mock_cache_stats_command):
+    @patch('time.sleep')
+    def test_execute_successful_server_start(self, mock_sleep,
+                                mock_containerize, mock_popen,
+                                mock_is_qlever_server_alive, mock_run_command,
+                                mock_cache_stats_command):
         # Setup args
         args = MagicMock()
         args.kill_existing_with_same_port = False
@@ -121,6 +161,15 @@ class TestStartCommand(unittest.TestCase):
         # Mock Popen
         mock_popen.return_value = MagicMock()
 
+        # Mock CacheStatsCommand
+        mock_cache_stats_command.return_value = None
+
+        # Mock Containerize
+        mock_containerize.return_value = None
+
+        # Mock sleep
+        mock_sleep.return_value = None
+
         # Instantiate the StartCommand
         sc = StartCommand()
 
@@ -128,9 +177,12 @@ class TestStartCommand(unittest.TestCase):
         result = sc.execute(args)
 
         # Assertions
-        mock_is_qlever_server_alive.assert_called()  # Server status should be checked
-        self.assertTrue(mock_run_command.called)  # Ensure the server was started
-        self.assertTrue(result)  # Ensure execution was successful
+        # Server status should be checked
+        mock_is_qlever_server_alive.assert_called()
+        # Ensure the server was started
+        self.assertTrue(mock_run_command.called)
+        # Ensure execution was successful
+        self.assertTrue(result)
 
     @patch('qlever.commands.start.CacheStatsCommand.execute')
     @patch('qlever.commands.start.run_command')
@@ -138,8 +190,9 @@ class TestStartCommand(unittest.TestCase):
     @patch('subprocess.Popen')
     @patch('subprocess.run')
     @patch('qlever.commands.start.Containerize')
-    def test_execute_server_with_warmup(self, mock_containerize, mock_run, mock_popen, mock_is_qlever_server_alive,
-                                        mock_run_command, mock_cache_stats_command):
+    def test_execute_server_with_warmup(self, mock_containerize, mock_run,
+                                mock_popen, mock_is_qlever_server_alive,
+                                mock_run_command, mock_cache_stats_command):
         # Setup args
         args = MagicMock()
         args.kill_existing_with_same_port = False
@@ -159,9 +212,14 @@ class TestStartCommand(unittest.TestCase):
         # Mock Popen
         mock_popen.return_value = MagicMock()
 
+        # Mock CacheStatsCommand
+        mock_cache_stats_command.return_value = None
+
+        # Mock Containerize
+        mock_containerize.return_value = None
+
         # Mock that no server is currently running
         mock_is_qlever_server_alive.side_effect = [False, True]
-
 
         # Instantiate the StartCommand
         sc = StartCommand()
@@ -170,12 +228,99 @@ class TestStartCommand(unittest.TestCase):
         result = sc.execute(args)
 
         # Check that Popen was called
-        mock_popen.assert_called_once_with(f"exec tail -f {args.name}.server-log.txt", shell=True)
+        mock_popen.assert_called_once_with(
+            f"exec tail -f {args.name}.server-log.txt", shell=True)
 
         # Check warmup was called
-        mock_run.assert_called_once_with(args.warmup_cmd, shell=True, check=True)
+        mock_run.assert_called_once_with(
+            args.warmup_cmd, shell=True, check=True)
 
         # Assertions
-        mock_is_qlever_server_alive.assert_called()  # Ensure the server status was checked
-        mock_run_command.assert_called()  # Ensure the server was started
-        self.assertTrue(result)  # Execution should succeed
+        # Ensure the server status was checked
+        mock_is_qlever_server_alive.assert_called()
+        # Ensure the server was started
+        mock_run_command.assert_called()
+        # Execution should succeed
+        self.assertTrue(result)
+
+    @patch('qlever.commands.start.CacheStatsCommand.execute')
+    @patch('qlever.commands.stop.StopCommand.execute', return_value=True)
+    @patch('qlever.commands.start.run_command')
+    @patch('qlever.commands.start.is_qlever_server_alive')
+    @patch('subprocess.Popen')
+    @patch('qlever.commands.start.Containerize.supported_systems')
+    @patch('qlever.commands.start.run_command_in_container')
+    @patch('qlever.commands.start.construct_command_line')
+    def test_execute_containerize_and_description(self,
+                                mock_construct_cl, mock_run_containerize,
+                                mock_containerize, mock_popen,
+                                mock_is_qlever_server_alive, mock_run_command,
+                                mock_stop, mock_cache_stats_command):
+        # Setup args
+        args = MagicMock()
+        args.kill_existing_with_same_port = True
+        args.port = 1234
+        args.server_binary = "/test/path/server_binary"
+        args.name = "TestName"
+        args.num_threads = 2
+        args.memory_for_queries = "8G"
+        args.cache_max_size = "2G"
+        args.cache_max_size_single_entry = "124M"
+        args.cache_max_num_entries = 1000
+        args.system = "test1"
+        args.show = False
+        args.description = "TestDescription"
+        args.text_description = "TestTextDescription"
+        args.access_token = "TestToken"
+
+        # Mock server is not alive initially, then alive after starting
+        mock_is_qlever_server_alive.side_effect = [False, True]
+
+        # Mock Popen
+        mock_popen.return_value = MagicMock()
+
+        # Mock construct_command_line
+        mock_construct_cl.return_value = "TestStart"
+
+        # Mock construct_command_line
+        mock_run_containerize.return_value = "TestStart2"
+
+        # mock StopCommand
+        mock_stop.return_value = None
+
+        # Mock CacheStatsCommand
+        mock_cache_stats_command.return_value = None
+
+        # Mock Containerize
+        mock_containerize.return_value = ["test1", "test2"]
+
+        # Instantiate the StartCommand
+        sc = StartCommand()
+
+        # Execute the function
+        result = sc.execute(args)
+
+        # Assertions
+        # check if run_command_in_container is called once
+        mock_run_containerize.assert_called_once_with(args, "TestStart")
+
+        # Calls for run command
+        run_call_1 = f"{args.system} rm -f {args.server_container}"
+        run_call_2 = "TestStart2"
+        access_arg = f"--data-urlencode \"access-token={args.access_token}\""
+        run_call_3 = (f"curl -Gs http://localhost:{args.port}/api"
+                f" --data-urlencode \"index-description={args.description}\""
+                f" {access_arg} > /dev/null")
+        run_call_4 = (f"curl -Gs http://localhost:{args.port}/api"
+                    f" --data-urlencode \"text-description="
+                    f"{args.text_description}\""
+                    f" {access_arg} > /dev/null")
+        # Assert that run_command was called exactly 4 times with the
+        # correct arguments in order
+        mock_run_command.assert_has_calls([call(run_call_1), call(run_call_2),
+                                        call(run_call_3), call(run_call_4)],
+                                        any_order=False)
+        # Server status should be checked
+        mock_is_qlever_server_alive.assert_called()
+        # Ensure execution was successful
+        self.assertTrue(result)

--- a/test/qlever/commands/test_start_other_methods
+++ b/test/qlever/commands/test_start_other_methods
@@ -1,0 +1,69 @@
+import unittest
+from qlever.commands.start import StartCommand
+import argparse
+
+
+class TestStartCommand(unittest.TestCase):
+    def test_description(self):
+        # Create an instance of IndexCommand
+        sc = StartCommand()
+
+        # Call the method
+        result = sc.description()
+
+        self.assertEqual(result, "Start the QLever server (requires that you have built "
+                "an index with `qlever index` before)")
+
+    def test_should_have_qleverfile(self):
+        # Create an instance of IndexCommand
+        sc = StartCommand()
+
+        # Call the method
+        result = sc.should_have_qleverfile()
+
+        assert result
+
+    def test_relevant_qleverfile_arguments(self):
+        # Create an instance of IndexCommand
+        sc = StartCommand()
+
+        # Call the method
+        result = sc.relevant_qleverfile_arguments()
+
+        self.assertEqual(result, {"data": ["name", "description", "text_description"],
+                "server": ["server_binary", "host_name", "port",
+                           "access_token", "memory_for_queries",
+                           "cache_max_size", "cache_max_size_single_entry",
+                           "cache_max_num_entries", "num_threads",
+                           "timeout", "only_pso_and_pos_permutations",
+                           "use_patterns", "use_text_index",
+                           "warmup_cmd"],
+                "runtime": ["system", "image", "server_container"]})
+
+    def test_additional_arguments(self):
+        # Create an instance of StopCommand
+        sc = StartCommand()
+
+        # Create a parser and a subparser
+        parser = argparse.ArgumentParser()
+        subparser = parser.add_argument_group('test')
+        # Call the method
+        sc.additional_arguments(subparser)
+        # Parse an empty argument list to see the default
+        args = parser.parse_args([])
+
+        # Test that the default value for cmdline_regex is set correctly
+        self.assertEqual(args.kill_existing_with_same_port, False)
+
+        # Test that the help text for --kill-existing-with-same-port is correctly set
+        argument_help = subparser._group_actions[-2].help
+        self.assertEqual(argument_help, "If a QLever server is already running "
+                                    "on the same port, kill it before "
+                                    "starting a new server")
+
+        # Test that the default value for --no-warmup is set correctly
+        self.assertEqual(args.no_warmup, False)
+
+        # Test that the help text for --no-warmup is correctly set
+        argument_help = subparser._group_actions[-1].help
+        self.assertEqual(argument_help, "Do not execute the warmup command")

--- a/test/qlever/commands/test_start_other_methods
+++ b/test/qlever/commands/test_start_other_methods
@@ -4,24 +4,14 @@ import argparse
 
 
 class TestStartCommand(unittest.TestCase):
+
     def test_description(self):
-        # Create an instance of IndexCommand
-        sc = StartCommand()
-
-        # Call the method
-        result = sc.description()
-
-        self.assertEqual(result, "Start the QLever server (requires that you have built "
-                "an index with `qlever index` before)")
+        self.assertEqual(StartCommand().description(), "Start the "
+                     "QLever server (requires that you have built "
+                     "an index with `qlever index` before)")
 
     def test_should_have_qleverfile(self):
-        # Create an instance of IndexCommand
-        sc = StartCommand()
-
-        # Call the method
-        result = sc.should_have_qleverfile()
-
-        assert result
+        assert StartCommand().should_have_qleverfile()
 
     def test_relevant_qleverfile_arguments(self):
         # Create an instance of IndexCommand
@@ -30,7 +20,8 @@ class TestStartCommand(unittest.TestCase):
         # Call the method
         result = sc.relevant_qleverfile_arguments()
 
-        self.assertEqual(result, {"data": ["name", "description", "text_description"],
+        self.assertEqual(result, {
+            "data": ["name", "description", "text_description"],
                 "server": ["server_binary", "host_name", "port",
                            "access_token", "memory_for_queries",
                            "cache_max_size", "cache_max_size_single_entry",
@@ -55,15 +46,18 @@ class TestStartCommand(unittest.TestCase):
         # Test that the default value for cmdline_regex is set correctly
         self.assertEqual(args.kill_existing_with_same_port, False)
 
-        # Test that the help text for --kill-existing-with-same-port is correctly set
+        # Test that the help text for
+        # --kill-existing-with-same-port is correctly set
         argument_help = subparser._group_actions[-2].help
-        self.assertEqual(argument_help, "If a QLever server is already running "
-                                    "on the same port, kill it before "
-                                    "starting a new server")
+        self.assertEqual(argument_help,
+                         "If a QLever server is already running "
+                                "on the same port, kill it before "
+                                "starting a new server")
 
         # Test that the default value for --no-warmup is set correctly
         self.assertEqual(args.no_warmup, False)
 
         # Test that the help text for --no-warmup is correctly set
         argument_help = subparser._group_actions[-1].help
-        self.assertEqual(argument_help, "Do not execute the warmup command")
+        self.assertEqual(argument_help,
+                         "Do not execute the warmup command")


### PR DESCRIPTION
Previously, the `start` command had a very long `execute` function which as of this PR now is refactored into smaller functions 
(e.g. for handling the native or containerized starting and for killing preexisting binaries or containers with the same port.
Also add unit tests (using mock tests) for the `start` command.