### PR TITLE
Only stop index container if one is actually running

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Script for using the QLever SPARQL engine."
-version = "0.5.6"
+version = "0.5.7"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -119,11 +119,13 @@ class IndexCommand(QleverCommand):
         # Remove already existing container.
         if args.system in Containerize.supported_systems() \
                 and args.overwrite_existing:
-            try:
-                run_command(f"{args.system} rm -f {args.index_container}")
-            except Exception as e:
-                log.error(f"Removing existing container failed: {e}")
-                return False
+            if Containerize.is_running(args.system, args.index_container):
+                log.info(f"An Index process is still running. Stopping it...")
+                try:
+                    run_command(f"{args.system} rm -f {args.index_container}")
+                except Exception as e:
+                    log.error(f"Removing existing container failed: {e}")
+                    return False
 
         # Write settings.json file.
         try:

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -120,7 +120,7 @@ class IndexCommand(QleverCommand):
         if args.system in Containerize.supported_systems() \
                 and args.overwrite_existing:
             if Containerize.is_running(args.system, args.index_container):
-                log.info(f"An Index process is still running. Stopping it...")
+                log.info("Another index process is running, trying to stop it ...")
                 try:
                     run_command(f"{args.system} rm -f {args.index_container}")
                 except Exception as e:

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -121,6 +121,7 @@ class IndexCommand(QleverCommand):
                 and args.overwrite_existing:
             if Containerize.is_running(args.system, args.index_container):
                 log.info("Another index process is running, trying to stop it ...")
+                log.info("")
                 try:
                     run_command(f"{args.system} rm -f {args.index_container}")
                 except Exception as e:

--- a/src/qlever/containerize.py
+++ b/src/qlever/containerize.py
@@ -81,16 +81,18 @@ class Containerize:
 
     @staticmethod
     def is_running(container_system: str, container_name: str) -> bool:
-        # Curly braces have to escaped in f-strings. "{{{{" results in "{{".
+        # Note: the `{{{{` and `}}}}` result in `{{` and `}}`, respectively.
         containers = (
-            run_command(f'{container_system} ps --format="{{{{.Names}}}}"', return_output=True)
+            run_command(f"{container_system} ps --format=\"{{{{.Names}}}}\"",
+                        return_output=True)
             .strip()
             .splitlines()
         )
         return container_name in containers
 
     @staticmethod
-    def stop_and_remove_container(container_system: str, container_name: str) -> bool:
+    def stop_and_remove_container(container_system: str,
+                                  container_name: str) -> bool:
         """
         Stop the container with the given name using the given system. Return
         `True` if a container with that name was found and stopped, `False`

--- a/src/qlever/containerize.py
+++ b/src/qlever/containerize.py
@@ -9,6 +9,7 @@ import subprocess
 from typing import Optional
 
 from qlever.log import log
+from qlever.util import run_command
 
 
 class ContainerizeException(Exception):
@@ -79,8 +80,17 @@ class Containerize:
         return containerized_cmd
 
     @staticmethod
-    def stop_and_remove_container(container_system: str,
-                                  container_name: str) -> bool:
+    def is_running(container_system: str, container_name: str) -> bool:
+        # Curly braces have to escaped in f-strings. "{{{{" results in "{{".
+        containers = (
+            run_command(f'{container_system} ps --format="{{{{.Names}}}}"', return_output=True)
+            .strip()
+            .splitlines()
+        )
+        return container_name in containers
+
+    @staticmethod
+    def stop_and_remove_container(container_system: str, container_name: str) -> bool:
         """
         Stop the container with the given name using the given system. Return
         `True` if a container with that name was found and stopped, `False`


### PR DESCRIPTION
So far, `qlever index` always called `docker rm -f ...` or `podman rm -f ...` before starting a new index build. However, old versions of podman return an error message when no container with the specified name is running. This is now fixed by checking explicitly whether a container is running and only if there is, trying to stop and remove it. Fixes #66.