### PR TITLE
Refactor the `stop` command

### DIFF
--- a/src/qlever/commands/stop.py
+++ b/src/qlever/commands/stop.py
@@ -74,7 +74,7 @@ class StopCommand(QleverCommand):
                             f"\"{args.server_container}\"")
         self.show(description, only_show=args.show)
         if args.show:
-            return False
+            return True
 
         # First check if there is container running and if yes, stop and remove
         # it (unless the user has specified `--no-containers`).
@@ -100,13 +100,12 @@ class StopCommand(QleverCommand):
                 log.info("")
                 return stop_process(proc, pinfo)
 
-        # No matching process found.
+        # If no matching process found, show a message and the output of the
+        # status command.
         message = "No matching process found" if args.no_containers else \
             "No matching process or container found"
         log.error(message)
-
-        # Show output of status command.
         args.cmdline_regex = "^ServerMain.* -i [^ ]*"
         log.info("")
         StatusCommand().execute(args)
-        return False
+        return True

--- a/src/qlever/commands/stop.py
+++ b/src/qlever/commands/stop.py
@@ -22,6 +22,16 @@ def try_to_kill(proc, pinfo):
     return True
 
 
+def check_stop_remove_container(server_container):
+    for container_system in Containerize.supported_systems():
+        if Containerize.stop_and_remove_container(
+                container_system, server_container):
+            log.info(f"{container_system.capitalize()} container with "
+                     f"name \"{server_container}\" stopped "
+                     f" and removed")
+            return True
+
+
 class StopCommand(QleverCommand):
     """
     Class for executing the `stop` command.
@@ -65,13 +75,8 @@ class StopCommand(QleverCommand):
         # First check if there is container running and if yes, stop and remove
         # it (unless the user has specified `--no-containers`).
         if not args.no_containers:
-            for container_system in Containerize.supported_systems():
-                if Containerize.stop_and_remove_container(
-                        container_system, args.server_container):
-                    log.info(f"{container_system.capitalize()} container with "
-                             f"name \"{args.server_container}\" stopped "
-                             f" and removed")
-                    return True
+            if check_stop_remove_container(args.server_container):
+                return True
 
         # Check if there is a process running on the server port using psutil.
         # NOTE: On MacOS, some of the proc's returned by psutil.process_iter()

--- a/src/qlever/commands/stop.py
+++ b/src/qlever/commands/stop.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
-
 import re
-
 import psutil
-
 from qlever.command import QleverCommand
 from qlever.commands.status import StatusCommand
 from qlever.containerize import Containerize
 from qlever.log import log
 from qlever.util import show_process_info
+
+
+def try_to_kill(proc, pinfo):
+    try:
+        proc.kill()
+        log.info(f"Killed process {pinfo['pid']}")
+    except Exception as e:
+        log.error(f"Could not kill process with PID "
+                  f"{pinfo['pid']} ({e}) ... try to kill it "
+                  f"manually")
+        log.info("")
+        show_process_info(proc, "", show_heading=True)
+        return False
+    return True
 
 
 class StopCommand(QleverCommand):
@@ -20,7 +31,7 @@ class StopCommand(QleverCommand):
         pass
 
     def description(self) -> str:
-        return ("Stop QLever server for a given datasedataset or port")
+        return "Stop QLever server for a given datasedataset or port"
 
     def should_have_qleverfile(self) -> bool:
         return True
@@ -63,41 +74,33 @@ class StopCommand(QleverCommand):
                     return True
 
         # Check if there is a process running on the server port using psutil.
-        #
         # NOTE: On MacOS, some of the proc's returned by psutil.process_iter()
         # no longer exist when we try to access them, so we just skip them.
         for proc in psutil.process_iter():
             try:
                 pinfo = proc.as_dict(
-                        attrs=['pid', 'username', 'create_time',
-                               'memory_info', 'cmdline'])
+                    attrs=['pid', 'username', 'create_time',
+                           'memory_info', 'cmdline'])
                 cmdline = " ".join(pinfo['cmdline'])
             except Exception as e:
                 log.debug(f"Error getting process info: {e}")
+                return False
             if re.search(cmdline_regex, cmdline):
                 log.info(f"Found process {pinfo['pid']} from user "
                          f"{pinfo['username']} with command line: {cmdline}")
                 log.info("")
-                try:
-                    proc.kill()
-                    log.info(f"Killed process {pinfo['pid']}")
-                except Exception as e:
-                    log.error(f"Could not kill process with PID "
-                              f"{pinfo['pid']} ({e}) ... try to kill it "
-                              f"manually")
-                    log.info("")
-                    show_process_info(proc, "", show_heading=True)
+                if try_to_kill(proc, pinfo):
+                    return True
+                else:
                     return False
-                return True
 
         # No matching process found.
         message = "No matching process found" if args.no_containers else \
-                  "No matching process or container found"
+            "No matching process or container found"
         log.error(message)
 
         # Show output of status command.
         args.cmdline_regex = "^ServerMain.* -i [^ ]*"
         log.info("")
         StatusCommand().execute(args)
-
         return False


### PR DESCRIPTION
Now several subfunctions are factored out from the rather lengthy `execute` function, in particular for stopping a native binary and for stopping a container.