### PR TITLE
New variable `MULTI_INPUT_JSON` for Qleverfile

### DIFF
--- a/src/qlever/Qleverfiles/Qleverfile.imdb
+++ b/src/qlever/Qleverfiles/Qleverfile.imdb
@@ -28,7 +28,7 @@ ACCESS_TOKEN       = ${data:NAME}
 MEMORY_FOR_QUERIES = 5G
 
 [runtime]
-SYSTEM = native
+SYSTEM = docker
 IMAGE  = docker.io/adfreiburg/qlever:latest
 
 [ui]

--- a/src/qlever/Qleverfiles/Qleverfile.wikidata
+++ b/src/qlever/Qleverfiles/Qleverfile.wikidata
@@ -1,15 +1,19 @@
-# Qleverfile for Wikidata, use with https://github.com/ad-freiburg/qlever-control
+# Qleverfile for Wikidata, use with the QLever CLI (`pip install qlever`)
 #
-# qlever get-data  # downloads two .bz2 files of total size ~100 GB
-# qlever index     # takes ~4 hours and ~20 GB RAM (on an AMD Ryzen 9 5900X)
-# qlever start     # starts the server (takes a few seconds)
+# qlever get-data  # ~7 hours, ~110 GB (compressed), ~20 billion triples
+# qlever index     # ~5 hours, ~20 GB RAM, ~500 GB (index size on disk)
+# qlever start     # a few seconds, adjust MEMORY_FOR_QUERIES as needed
+#
+# Adding a text index takes an additional ~2 hours and ~50 GB of disk space.
+#
+# Measured on an AMD Ryzen 9 5950X with 128 GB RAM, and NVMe SSD (18.10.2024).
 
 [DEFAULT]
 NAME = wikidata
 
 [data]
 GET_DATA_URL      = https://dumps.wikimedia.org/wikidatawiki/entities
-GET_DATA_CMD      = curl -L -C - --remote-time --remote-name-all ${GET_DATA_URL}/latest-all.ttl.bz2 ${GET_DATA_URL}/latest-lexemes.ttl.bz2 2>&1 && curl -sL ${GET_DATA_URL}/dcatap.rdf | docker run -i --rm -v $$(pwd):/data stain/jena riot --syntax=RDF/XML --output=NT /dev/stdin > dcatap.nt
+GET_DATA_CMD      = curl -LROC - ${GET_DATA_URL}/latest-all.ttl.bz2 ${GET_DATA_URL}/latest-lexemes.ttl.bz2 2>&1 | tee wikidata.download-log.txt && curl -sL ${GET_DATA_URL}/dcatap.rdf | docker run -i --rm -v $$(pwd):/data stain/jena riot --syntax=RDF/XML --output=NT /dev/stdin > dcatap.nt
 DATE_WIKIDATA     = $$(date -r latest-all.ttl.bz2 +%d.%m.%Y || echo "NO_DATE")
 DATE_WIKIPEDIA    = $$(date -r wikipedia-abstracts.nt +%d.%m.%Y || echo "NO_DATE")
 DESCRIPTION       = Full Wikidata dump from ${GET_DATA_URL} (latest-all.ttl.bz2 and latest-lexemes.ttl.bz2, version ${DATE_WIKIDATA}) + English Wikipeda abstracts (version ${DATE_WIKIPEDIA}, available via schema:description)

--- a/src/qlever/Qleverfiles/Qleverfile.wikidata
+++ b/src/qlever/Qleverfiles/Qleverfile.wikidata
@@ -1,33 +1,42 @@
-# Qleverfile for Wikidata, use with qlever script (`pip install qlever`)
+# Qleverfile for Wikidata, use with https://github.com/ad-freiburg/qlever-control
 #
 # qlever get-data  # downloads two .bz2 files of total size ~100 GB
-# qlever index     # takes ~4.5 hours and ~20 GB RAM (on an AMD Ryzen 9 5900X)
+# qlever index     # takes ~4 hours and ~20 GB RAM (on an AMD Ryzen 9 5900X)
 # qlever start     # starts the server (takes a few seconds)
 
 [DEFAULT]
 NAME = wikidata
 
 [data]
-GET_DATA_URL = https://dumps.wikimedia.org/wikidatawiki/entities
-GET_DATA_CMD = curl -LRC - --remote-name-all ${GET_DATA_URL}/latest-all.ttl.bz2 ${GET_DATA_URL}/latest-lexemes.ttl.bz2 2>&1
-VERSION      = $$(date -r latest-all.ttl.bz2 +%d.%m.%Y || echo "NO_DATE")
-DESCRIPTION  = Full Wikidata dump from ${GET_DATA_URL} (latest-all.ttl.bz2 and latest-lexemes.ttl.bz2, version ${VERSION})
+GET_DATA_URL      = https://dumps.wikimedia.org/wikidatawiki/entities
+GET_DATA_CMD      = curl -L -C - --remote-time --remote-name-all ${GET_DATA_URL}/latest-all.ttl.bz2 ${GET_DATA_URL}/latest-lexemes.ttl.bz2 2>&1 && curl -sL ${GET_DATA_URL}/dcatap.rdf | docker run -i --rm -v $$(pwd):/data stain/jena riot --syntax=RDF/XML --output=NT /dev/stdin > dcatap.nt
+DATE_WIKIDATA     = $$(date -r latest-all.ttl.bz2 +%d.%m.%Y || echo "NO_DATE")
+DATE_WIKIPEDIA    = $$(date -r wikipedia-abstracts.nt +%d.%m.%Y || echo "NO_DATE")
+DESCRIPTION       = Full Wikidata dump from ${GET_DATA_URL} (latest-all.ttl.bz2 and latest-lexemes.ttl.bz2, version ${DATE_WIKIDATA}) + English Wikipeda abstracts (version ${DATE_WIKIPEDIA}, available via schema:description)
+TEXT_DESCRIPTION  = All English and German literals + all sentences from the English Wikipedia (version ${DATE_WIKIPEDIA}), use with FILTER KEYWORDS(...)
 
 [index]
-INPUT_FILES     = latest-all.ttl.bz2 latest-lexemes.ttl.bz2
-CAT_INPUT_FILES = lbzcat -n 4 -f ${INPUT_FILES}
-SETTINGS_JSON   = { "languages-internal": [], "prefixes-external": [""], "locale": { "language": "en", "country": "US", "ignore-punctuation": true }, "ascii-prefixes-only": true, "num-triples-per-batch": 5000000 }
-STXXL_MEMORY    = 10G
+INPUT_FILES      = latest-all.ttl.bz2 latest-lexemes.ttl.bz2 wikipedia-abstracts.nt dcatap.nt
+MULTI_INPUT_JSON = [{ "cmd": "lbzcat -n 4 latest-all.ttl.bz2", "format": "ttl", "parallel": "true" },
+                    { "cmd": "lbzcat -n 1 latest-lexemes.ttl.bz2", "format": "ttl", "parallel": "false" },
+                    { "cmd": "cat wikipedia-abstracts.nt", "format": "nt", "parallel": "false" },
+                    { "cmd": "cat dcatap.nt", "format": "nt", "parallel": "false" }]
+SETTINGS_JSON    = { "languages-internal": [], "prefixes-external": [""], "locale": { "language": "en", "country": "US", "ignore-punctuation": true }, "ascii-prefixes-only": true, "num-triples-per-batch": 5000000 }
+STXXL_MEMORY     = 10G
+TEXT_INDEX       = from_text_records
 
 [server]
-PORT               = 7001
-ACCESS_TOKEN       = ${data:NAME}
-MEMORY_FOR_QUERIES = 20G
-CACHE_MAX_SIZE     = 10G
+PORT                        = 7001
+ACCESS_TOKEN                = ${data:NAME}_3fz47hfzrbf64b
+MEMORY_FOR_QUERIES          = 40G
+CACHE_MAX_SIZE              = 30G
+CACHE_MAX_SIZE_SINGLE_ENTRY = 5G
+# WARMUP_CMD                  = curl -s http://localhost:${PORT} -H "Accept: application/qlever-results+json" --data-urlencode "query=PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?subject ?label WHERE { ?subject @en@rdfs:label ?label } INTERNAL SORT BY ?subject" --data-urlencode "access-token=${server:ACCESS_TOKEN}" --data-urlencode "pinresult=true" --data-urlencode "send=0" | jq .resultsize | xargs printf "Result size: %'d\n"
+TIMEOUT                     = 300s
 
 [runtime]
-SYSTEM = docker
-IMAGE  = docker.io/adfreiburg/qlever:latest
+SYSTEM = native
+IMAGE  = adfreiburg/qlever
 
 [ui]
 UI_CONFIG = wikidata

--- a/src/qlever/Qleverfiles/Qleverfile.wikidata
+++ b/src/qlever/Qleverfiles/Qleverfile.wikidata
@@ -35,11 +35,10 @@ ACCESS_TOKEN                = ${data:NAME}_3fz47hfzrbf64b
 MEMORY_FOR_QUERIES          = 40G
 CACHE_MAX_SIZE              = 30G
 CACHE_MAX_SIZE_SINGLE_ENTRY = 5G
-# WARMUP_CMD                  = curl -s http://localhost:${PORT} -H "Accept: application/qlever-results+json" --data-urlencode "query=PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?subject ?label WHERE { ?subject @en@rdfs:label ?label } INTERNAL SORT BY ?subject" --data-urlencode "access-token=${server:ACCESS_TOKEN}" --data-urlencode "pinresult=true" --data-urlencode "send=0" | jq .resultsize | xargs printf "Result size: %'d\n"
 TIMEOUT                     = 300s
 
 [runtime]
-SYSTEM = native
+SYSTEM = docker
 IMAGE  = adfreiburg/qlever
 
 [ui]

--- a/src/qlever/commands/example_queries.py
+++ b/src/qlever/commands/example_queries.py
@@ -22,67 +22,97 @@ class ExampleQueriesCommand(QleverCommand):
 
     def __init__(self):
         self.presets = {
-                "virtuoso-wikidata":
-                "https://wikidata.demo.openlinksw.com/sparql",
-                "qlever-wikidata":
-                "https://qlever.cs.uni-freiburg.de/api/wikidata"
-                }
+            "virtuoso-wikidata": "https://wikidata.demo.openlinksw.com/sparql",
+            "qlever-wikidata": "https://qlever.cs.uni-freiburg.de/api/wikidata",
+        }
 
     def description(self) -> str:
-        return ("Show how much of the cache is currently being used")
+        return "Show how much of the cache is currently being used"
 
     def should_have_qleverfile(self) -> bool:
         return False
 
-    def relevant_qleverfile_arguments(self) -> dict[str: list[str]]:
+    def relevant_qleverfile_arguments(self) -> dict[str : list[str]]:
         return {"server": ["port"], "ui": ["ui_config"]}
 
     def additional_arguments(self, subparser) -> None:
-        subparser.add_argument("--sparql-endpoint", type=str,
-                               help="URL of the SPARQL endpoint")
-        subparser.add_argument("--sparql-endpoint-preset",
-                               choices=self.presets.keys(),
-                               help="Shortcut for setting the SPARQL endpoint")
-        subparser.add_argument("--get-queries-cmd", type=str,
-                               help="Command to get example queries as TSV "
-                               "(description, query)")
-        subparser.add_argument("--query-ids", type=str,
-                               default="1-$",
-                               help="Query IDs as comma-separated list of "
-                               "ranges (e.g., 1-5,7,12-$)")
-        subparser.add_argument("--query-regex", type=str,
-                               help="Only consider example queries matching "
-                               "this regex (using grep -Pi)")
-        subparser.add_argument("--download-or-count",
-                               choices=["download", "count"], default="count",
-                               help="Whether to download the full result "
-                               "or just compute the size of the result")
-        subparser.add_argument("--limit", type=int,
-                               help="Limit on the number of results")
-        subparser.add_argument("--remove-offset-and-limit",
-                               action="store_true", default=False,
-                               help="Remove OFFSET and LIMIT from the query")
-        subparser.add_argument("--accept", type=str,
-                               choices=["text/tab-separated-values",
-                                        "text/csv",
-                                        "application/sparql-results+json",
-                                        "text/turtle"],
-                               default="text/tab-separated-values",
-                               help="Accept header for the SPARQL query")
-        subparser.add_argument("--clear-cache",
-                               choices=["yes", "no"],
-                               default="yes",
-                               help="Clear the cache before each query")
-        subparser.add_argument("--width-query-description", type=int,
-                               default=40,
-                               help="Width for printing the query description")
-        subparser.add_argument("--width-error-message", type=int,
-                               default=80,
-                               help="Width for printing the error message "
-                               "(0 = no limit)")
-        subparser.add_argument("--width-result-size", type=int,
-                               default=14,
-                               help="Width for printing the result size")
+        subparser.add_argument(
+            "--sparql-endpoint", type=str, help="URL of the SPARQL endpoint"
+        )
+        subparser.add_argument(
+            "--sparql-endpoint-preset",
+            choices=self.presets.keys(),
+            help="Shortcut for setting the SPARQL endpoint",
+        )
+        subparser.add_argument(
+            "--get-queries-cmd",
+            type=str,
+            help="Command to get example queries as TSV " "(description, query)",
+        )
+        subparser.add_argument(
+            "--query-ids",
+            type=str,
+            default="1-$",
+            help="Query IDs as comma-separated list of " "ranges (e.g., 1-5,7,12-$)",
+        )
+        subparser.add_argument(
+            "--query-regex",
+            type=str,
+            help="Only consider example queries matching "
+            "this regex (using grep -Pi)",
+        )
+        subparser.add_argument(
+            "--download-or-count",
+            choices=["download", "count"],
+            default="count",
+            help="Whether to download the full result "
+            "or just compute the size of the result",
+        )
+        subparser.add_argument(
+            "--limit", type=int, help="Limit on the number of results"
+        )
+        subparser.add_argument(
+            "--remove-offset-and-limit",
+            action="store_true",
+            default=False,
+            help="Remove OFFSET and LIMIT from the query",
+        )
+        subparser.add_argument(
+            "--accept",
+            type=str,
+            choices=[
+                "text/tab-separated-values",
+                "text/csv",
+                "application/sparql-results+json",
+                "text/turtle",
+            ],
+            default="text/tab-separated-values",
+            help="Accept header for the SPARQL query",
+        )
+        subparser.add_argument(
+            "--clear-cache",
+            choices=["yes", "no"],
+            default="yes",
+            help="Clear the cache before each query",
+        )
+        subparser.add_argument(
+            "--width-query-description",
+            type=int,
+            default=40,
+            help="Width for printing the query description",
+        )
+        subparser.add_argument(
+            "--width-error-message",
+            type=int,
+            default=80,
+            help="Width for printing the error message " "(0 = no limit)",
+        )
+        subparser.add_argument(
+            "--width-result-size",
+            type=int,
+            default=14,
+            help="Width for printing the result size",
+        )
 
     def execute(self, args) -> bool:
         # We can't have both `--remove-offset-and-limit` and `--limit`.
@@ -93,9 +123,13 @@ class ExampleQueriesCommand(QleverCommand):
         # If `args.accept` is `application/sparql-results+json`, we need `jq`.
         if args.accept == "application/sparql-results+json":
             try:
-                subprocess.run("jq --version", shell=True, check=True,
-                               stdout=subprocess.DEVNULL,
-                               stderr=subprocess.DEVNULL)
+                subprocess.run(
+                    "jq --version",
+                    shell=True,
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
             except Exception as e:
                 log.error(f"Please install `jq` for {args.accept} ({e})")
                 return False
@@ -111,38 +145,44 @@ class ExampleQueriesCommand(QleverCommand):
             return False
 
         # Clear cache only works for QLever.
-        is_qlever = (not args.sparql_endpoint
-                     or args.sparql_endpoint.startswith("https://qlever"))
+        is_qlever = not args.sparql_endpoint or args.sparql_endpoint.startswith(
+            "https://qlever"
+        )
         if args.clear_cache == "yes" and not is_qlever:
             log.warning("Clearing the cache only works for QLever")
             args.clear_cache = "no"
 
         # Show what the command will do.
-        get_queries_cmd = (args.get_queries_cmd if args.get_queries_cmd
-                           else f"curl -sv https://qlever.cs.uni-freiburg.de/"
-                                f"api/examples/{args.ui_config}")
+        get_queries_cmd = (
+            args.get_queries_cmd
+            if args.get_queries_cmd
+            else f"curl -sv https://qlever.cs.uni-freiburg.de/"
+            f"api/examples/{args.ui_config}"
+        )
         sed_arg = args.query_ids.replace(",", "p;").replace("-", ",") + "p"
         get_queries_cmd += f" | sed -n '{sed_arg}'"
         if args.query_regex:
             get_queries_cmd += f" | grep -Pi {shlex.quote(args.query_regex)}"
-        sparql_endpoint = (args.sparql_endpoint if args.sparql_endpoint
-                           else f"localhost:{args.port}")
-        self.show(f"Obtain queries via: {get_queries_cmd}\n"
-                  f"SPARQL endpoint: {sparql_endpoint}\n"
-                  f"Accept header: {args.accept}\n"
-                  f"Clear cache before each query:"
-                  f" {args.clear_cache.upper()}\n"
-                  f"Download result for each query or just count:"
-                  f" {args.download_or_count.upper()}" +
-                  (f" with LIMIT {args.limit}" if args.limit else ""),
-                  only_show=args.show)
+        sparql_endpoint = (
+            args.sparql_endpoint if args.sparql_endpoint else f"localhost:{args.port}"
+        )
+        self.show(
+            f"Obtain queries via: {get_queries_cmd}\n"
+            f"SPARQL endpoint: {sparql_endpoint}\n"
+            f"Accept header: {args.accept}\n"
+            f"Clear cache before each query:"
+            f" {args.clear_cache.upper()}\n"
+            f"Download result for each query or just count:"
+            f" {args.download_or_count.upper()}"
+            + (f" with LIMIT {args.limit}" if args.limit else ""),
+            only_show=args.show,
+        )
         if args.show:
             return False
 
         # Get the example queries.
         try:
-            example_query_lines = run_command(get_queries_cmd,
-                                              return_output=True)
+            example_query_lines = run_command(get_queries_cmd, return_output=True)
             if len(example_query_lines) == 0:
                 log.error("No example queries matching the criteria found")
                 return False
@@ -152,11 +192,11 @@ class ExampleQueriesCommand(QleverCommand):
             return False
 
         # Launch the queries one after the other and for each print: the
-        # description, the result size, and the query processing time.
-        total_time_seconds = 0.0
-        total_result_size = 0
-        count_succeeded = 0
-        count_failed = 0
+        # description, the result size (number of rows), and the query
+        # processing time (seconds).
+        query_times = []
+        result_sizes = []
+        num_failed = 0
         for example_query_line in example_query_lines:
             # Parse description and query.
             description, query = example_query_line.split("\t")
@@ -176,13 +216,17 @@ class ExampleQueriesCommand(QleverCommand):
             # Remove OFFSET and LIMIT (after the last closing bracket).
             if args.remove_offset_and_limit or args.limit:
                 closing_bracket_idx = query.rfind("}")
-                regexes = [re.compile(r"OFFSET\s+\d+\s*", re.IGNORECASE),
-                           re.compile(r"LIMIT\s+\d+\s*", re.IGNORECASE)]
+                regexes = [
+                    re.compile(r"OFFSET\s+\d+\s*", re.IGNORECASE),
+                    re.compile(r"LIMIT\s+\d+\s*", re.IGNORECASE),
+                ]
                 for regex in regexes:
                     match = re.search(regex, query[closing_bracket_idx:])
                     if match:
-                        query = query[:closing_bracket_idx + match.start()] + \
-                                query[closing_bracket_idx + match.end():]
+                        query = (
+                            query[: closing_bracket_idx + match.start()]
+                            + query[closing_bracket_idx + match.end() :]
+                        )
 
             # Limit query.
             if args.limit:
@@ -191,19 +235,29 @@ class ExampleQueriesCommand(QleverCommand):
             # Count query.
             if args.download_or_count == "count":
                 # First find out if there is a FROM clause.
-                regex_from_clause = re.compile(r"\s*FROM\s+<[^>]+>\s*",
-                                               re.IGNORECASE)
+                regex_from_clause = re.compile(r"\s*FROM\s+<[^>]+>\s*", re.IGNORECASE)
                 match_from_clause = re.search(regex_from_clause, query)
                 from_clause = " "
                 if match_from_clause:
                     from_clause = match_from_clause.group(0)
-                    query = (query[:match_from_clause.start()] + " " +
-                             query[match_from_clause.end():])
+                    query = (
+                        query[: match_from_clause.start()]
+                        + " "
+                        + query[match_from_clause.end() :]
+                    )
                 # Now we can add the outer SELECT COUNT(*).
-                query = re.sub(r"SELECT ",
-                               "SELECT (COUNT(*) AS ?qlever_count_)"
-                               + from_clause + "WHERE { SELECT ",
-                               query, count=1, flags=re.IGNORECASE) + " }"
+                query = (
+                    re.sub(
+                        r"SELECT ",
+                        "SELECT (COUNT(*) AS ?qlever_count_)"
+                        + from_clause
+                        + "WHERE { SELECT ",
+                        query,
+                        count=1,
+                        flags=re.IGNORECASE,
+                    )
+                    + " }"
+                )
 
             # A bit of pretty-printing.
             query = re.sub(r"\s+", " ", query)
@@ -211,21 +265,27 @@ class ExampleQueriesCommand(QleverCommand):
 
             # Launch query.
             try:
-                curl_cmd = (f"curl -s {sparql_endpoint}"
-                            f" -w \"HTTP code: %{{http_code}}\\n\""
-                            f" -H \"Accept: {args.accept}\""
-                            f" --data-urlencode query={shlex.quote(query)}")
+                curl_cmd = (
+                    f"curl -s {sparql_endpoint}"
+                    f' -w "HTTP code: %{{http_code}}\\n"'
+                    f' -H "Accept: {args.accept}"'
+                    f" --data-urlencode query={shlex.quote(query)}"
+                )
                 log.debug(curl_cmd)
-                result_file = (f"qlever.example_queries.result."
-                               f"{abs(hash(curl_cmd))}.tmp")
+                result_file = (
+                    f"qlever.example_queries.result." f"{abs(hash(curl_cmd))}.tmp"
+                )
                 start_time = time.time()
-                http_code = run_curl_command(sparql_endpoint,
-                                             headers={"Accept": args.accept},
-                                             params={"query": query},
-                                             result_file=result_file).strip()
+                http_code = run_curl_command(
+                    sparql_endpoint,
+                    headers={"Accept": args.accept},
+                    params={"query": query},
+                    result_file=result_file,
+                ).strip()
                 if http_code != "200":
-                    raise Exception(f"HTTP code {http_code}"
-                                    f"  {Path(result_file).read_text()}")
+                    raise Exception(
+                        f"HTTP code {http_code}" f"  {Path(result_file).read_text()}"
+                    )
                 time_seconds = time.time() - start_time
                 error_msg = None
             except Exception as e:
@@ -240,30 +300,34 @@ class ExampleQueriesCommand(QleverCommand):
                     if args.download_or_count == "count":
                         if args.accept == "text/tab-separated-values":
                             result_size = run_command(
-                                    f"sed 1d {result_file}",
-                                    return_output=True)
+                                f"sed 1d {result_file}", return_output=True
+                            )
                         else:
                             result_size = run_command(
-                                    f"jq -r \".results.bindings[0]"
-                                    f" | to_entries[0].value.value"
-                                    f" | tonumber\" {result_file}",
-                                    return_output=True)
+                                f'jq -r ".results.bindings[0]'
+                                f" | to_entries[0].value.value"
+                                f' | tonumber" {result_file}',
+                                return_output=True,
+                            )
                     else:
-                        if (args.accept == "text/tab-separated-values"
-                                or args.accept == "text/csv"):
+                        if (
+                            args.accept == "text/tab-separated-values"
+                            or args.accept == "text/csv"
+                        ):
                             result_size = run_command(
-                                    f"sed 1d {result_file} | wc -l",
-                                    return_output=True)
+                                f"sed 1d {result_file} | wc -l", return_output=True
+                            )
                         elif args.accept == "text/turtle":
                             result_size = run_command(
-                                    f"sed '1d;/^@prefix/d;/^\\s*$/d' "
-                                    f"{result_file} | wc -l",
-                                    return_output=True)
+                                f"sed '1d;/^@prefix/d;/^\\s*$/d' "
+                                f"{result_file} | wc -l",
+                                return_output=True,
+                            )
                         else:
                             result_size = run_command(
-                                    f"jq -r \".results.bindings | length\""
-                                    f" {result_file}",
-                                    return_output=True)
+                                f'jq -r ".results.bindings | length"' f" {result_file}",
+                                return_output=True,
+                            )
                     result_size = int(result_size)
                 except Exception as e:
                     error_msg = str(e)
@@ -274,43 +338,79 @@ class ExampleQueriesCommand(QleverCommand):
 
             # Print description, time, result in tabular form.
             if len(description) > args.width_query_description:
-                description = description[:args.width_query_description - 3]
+                description = description[: args.width_query_description - 3]
                 description += "..."
             if error_msg is None:
-                log.info(f"{description:<{args.width_query_description}}  "
-                         f"{time_seconds:6.2f} s  "
-                         f"{result_size:>{args.width_result_size},}")
-                count_succeeded += 1
-                total_time_seconds += time_seconds
-                total_result_size += result_size
+                log.info(
+                    f"{description:<{args.width_query_description}}  "
+                    f"{time_seconds:6.2f} s  "
+                    f"{result_size:>{args.width_result_size},}"
+                )
+                query_times.append(time_seconds)
+                result_sizes.append(result_size)
             else:
-                count_failed += 1
-                if (args.width_error_message > 0
-                        and len(error_msg) > args.width_error_message
-                        and args.log_level != "DEBUG"):
-                    error_msg = error_msg[:args.width_error_message - 3]
+                num_failed += 1
+                if (
+                    args.width_error_message > 0
+                    and len(error_msg) > args.width_error_message
+                    and args.log_level != "DEBUG"
+                ):
+                    error_msg = error_msg[: args.width_error_message - 3]
                     error_msg += "..."
-                log.error(f"{description:<{args.width_query_description}}    "
-                          f"failed   "
-                          f"{colored(error_msg, 'red')}")
+                log.error(
+                    f"{description:<{args.width_query_description}}    "
+                    f"failed   "
+                    f"{colored(error_msg, 'red')}"
+                )
 
-        # Print total time.
-        log.info("")
-        if count_succeeded > 0:
-            query_or_queries = "query" if count_succeeded == 1 else "queries"
-            description = (f"TOTAL   for {count_succeeded} {query_or_queries}")
-            log.info(f"{description:<{args.width_query_description}}  "
-                     f"{total_time_seconds:6.2f} s  "
-                     f"{total_result_size:>14,}")
-            description = (f"AVERAGE for {count_succeeded} {query_or_queries}")
-            log.info(f"{description:<{args.width_query_description}}  "
-                     f"{total_time_seconds / count_succeeded:6.2f} s  "
-                     f"{round(total_result_size / count_succeeded):>14,}")
-        else:
-            if count_failed == 1:
-                log.info(colored("One query failed", "red"))
-            elif count_failed > 1:
-                log.info(colored("All queries failed", "red"))
+        # Check that each query has a time and a result size, or it failed.
+        assert len(result_sizes) == len(query_times)
+        assert len(query_times) + num_failed == len(example_query_lines)
+
+        # Show statistics.
+        if len(query_times) > 0:
+            n = len(query_times)
+            total_query_time = sum(query_times)
+            average_query_time = total_query_time / n
+            median_query_time = sorted(query_times)[n // 2]
+            total_result_size = sum(result_sizes)
+            average_result_size = round(total_result_size / n)
+            median_result_size = sorted(result_sizes)[n // 2]
+            query_or_queries = "query" if n == 1 else "queries"
+            description = f"TOTAL   for {n} {query_or_queries}"
+            log.info("")
+            log.info(
+                f"{description:<{args.width_query_description}}  "
+                f"{total_query_time:6.2f} s  "
+                f"{total_result_size:>14,}"
+            )
+            description = f"AVERAGE for {n} {query_or_queries}"
+            log.info(
+                f"{description:<{args.width_query_description}}  "
+                f"{average_query_time:6.2f} s  "
+                f"{average_result_size:>14,}"
+            )
+            description = f"MEDIAN  for {n} {query_or_queries}"
+            log.info(
+                f"{description:<{args.width_query_description}}  "
+                f"{median_query_time:6.2f} s  "
+                f"{median_result_size:>14,}"
+            )
+
+        # Show number of failed queries.
+        if num_failed > 0:
+            log.info("")
+            description = "Number of FAILED queries"
+            num_failed_string = f"{num_failed:>6}"
+            if num_failed == len(example_query_lines):
+                num_failed_string += "  [all]"
+            log.info(
+                colored(
+                    f"{description:<{args.width_query_description}}  "
+                    f"{num_failed:>24}",
+                    "red",
+                )
+            )
 
         # Return success (has nothing to do with how many queries failed).
         return True

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -55,7 +55,6 @@ class IndexCommand(QleverCommand):
             raise self.InvalidInputJson(
                     f"Failed to parse `MULTI_INPUT_JSON` ({e})",
                     args.multi_input_json)
-            raise Exception("")
         # Check that it is an array of length at least one.
         if not isinstance(input_specs, list):
             raise self.InvalidInputJson(
@@ -93,7 +92,10 @@ class IndexCommand(QleverCommand):
                         f"Element {i} in `MULTI_INPUT_JSON` must only contain "
                         "the keys `format`, `graph`, and `parallel`",
                         input_spec)
-            # Add the command-line options for this input stream.
+            # Add the command-line options for this input stream. We use
+            # process substitution `<(...)` as a convenient way to handle
+            # an input stream just like a file. This is not POSIX compliant,
+            # but supported by various shells, including bash and zsh.
             input_options.append(
                     f"-f <({input_cmd}) -F {input_format} "
                     f"-g \"{input_graph}\" -p {input_parallel}")

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import json
 import shlex
 
 from qlever.command import QleverCommand
@@ -26,8 +27,8 @@ class IndexCommand(QleverCommand):
 
     def relevant_qleverfile_arguments(self) -> dict[str: list[str]]:
         return {"data": ["name", "format"],
-                "index": ["input_files", "cat_input_files", "settings_json",
-                          "index_binary",
+                "index": ["input_files", "cat_input_files", "multi_input_json",
+                          "settings_json", "index_binary",
                           "only_pso_and_pos_permutations", "use_patterns",
                           "text_index", "stxxl_memory"],
                 "runtime": ["system", "image", "index_container"]}
@@ -38,12 +39,95 @@ class IndexCommand(QleverCommand):
                 default=False,
                 help="Overwrite an existing index, think twice before using.")
 
+    # Exception for invalid JSON.
+    class InvalidInputJson(Exception):
+        def __init__(self, error_message, additional_info):
+            self.error_message = error_message
+            self.additional_info = additional_info
+            super().__init__()
+
+    # Helper function to get command line options from JSON.
+    def get_input_options_for_json(self, args) -> str:
+        # Parse the JSON.
+        try:
+            input_specs = json.loads(args.multi_input_json)
+        except Exception as e:
+            raise self.InvalidInputJson(
+                    f"Failed to parse `MULTI_INPUT_JSON` ({e})",
+                    args.multi_input_json)
+            raise Exception("")
+        # Check that it is an array of length at least one.
+        if not isinstance(input_specs, list):
+            raise self.InvalidInputJson(
+                    "`MULTI_INPUT_JSON` must be a JSON array",
+                    args.multi_input_json)
+        if len(input_specs) == 0:
+            raise self.InvalidInputJson(
+                    "`MULTI_INPUT_JSON` must contain at least one element",
+                    args.multi_input_json)
+        # For each of the maps, construct the corresponding command-line
+        # options to the index binary.
+        input_options = []
+        for i, input_spec in enumerate(input_specs):
+            # Check that `input_spec` is a dictionary.
+            if not isinstance(input_spec, dict):
+                raise self.InvalidInputJson(
+                        f"Element {i} in `MULTI_INPUT_JSON` must be a JSON "
+                        "object",
+                        input_spec)
+            # For each `input_spec`, we must have a command.
+            if "cmd" not in input_spec:
+                raise self.InvalidInputJson(
+                        f"Element {i} in `MULTI_INPUT_JSON` must contain a "
+                        "key `cmd`",
+                        input_spec)
+            input_cmd = input_spec["cmd"]
+            # The `format`, `graph`, and `parallel` keys are optional.
+            input_format = input_spec.get("format", args.format)
+            input_graph = input_spec.get("graph", "-")
+            input_parallel = input_spec.get("parallel", "false")
+            # There must not be any other keys.
+            if not all(key in ["cmd", "format", "graph", "parallel"]
+                       for key in input_spec.keys()):
+                raise self.InvalidInputJson(
+                        f"Element {i} in `MULTI_INPUT_JSON` must only contain "
+                        "the keys `format`, `graph`, and `parallel`",
+                        input_spec)
+            # Add the command-line options for this input stream.
+            input_options.append(
+                    f"-f <({input_cmd}) -F {input_format} "
+                    f"-g \"{input_graph}\" -p {input_parallel}")
+        # Return the concatenated command-line options.
+        return " ".join(input_options)
+
     def execute(self, args) -> bool:
-        # Construct the command line.
-        index_cmd = (f"{args.cat_input_files} | {args.index_binary}"
-                     f" -F {args.format} -f -"
-                     f" -i {args.name}"
-                     f" -s {args.name}.settings.json")
+        # The mandatory part of the command line (specifying the input, the
+        # basename of the index, and the settings file). There are two ways
+        # to specify the input: via a single stream or via multiple streams.
+        if args.cat_input_files and not args.multi_input_json:
+            index_cmd = (f"{args.cat_input_files} | {args.index_binary}"
+                         f" -i {args.name} -s {args.name}.settings.json"
+                         f" -F {args.format} -f -")
+        elif args.multi_input_json and not args.cat_input_files:
+            try:
+                input_options = self.get_input_options_for_json(args)
+            except self.InvalidInputJson as e:
+                log.error(e.error_message)
+                log.info("")
+                log.info(e.additional_info)
+                return False
+            index_cmd = (f"{args.index_binary}"
+                         f" -i {args.name} -s {args.name}.settings.json"
+                         f" {input_options}")
+        else:
+            log.error("Specify exactly one of `CAT_INPUT_FILES` (for a "
+                      "single input stream) or `MULTI_INPUT_JSON` (for "
+                      "multiple input streams)")
+            log.info("")
+            log.info("See `qlever index --help` for more information")
+            return False
+
+        # Add remaining options.
         if args.only_pso_and_pos_permutations:
             index_cmd += " --only-pso-and-pos-permutations --no-patterns"
         if not args.use_patterns:
@@ -120,7 +204,8 @@ class IndexCommand(QleverCommand):
         if args.system in Containerize.supported_systems() \
                 and args.overwrite_existing:
             if Containerize.is_running(args.system, args.index_container):
-                log.info("Another index process is running, trying to stop it ...")
+                log.info("Another index process is running, trying to stop "
+                         "it ...")
                 log.info("")
                 try:
                     run_command(f"{args.system} rm -f {args.index_container}")

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-import socket
 import subprocess
 from configparser import ConfigParser, ExtendedInterpolation
 
@@ -63,8 +62,16 @@ class Qleverfile:
                 help="A space-separated list of patterns that match "
                      "all the files of the dataset")
         index_args["cat_input_files"] = arg(
-                "--cat-input-files", type=str, required=True,
+                "--cat-input-files", type=str,
                 help="The command that produces the input")
+        index_args["multi_input_json"] = arg(
+                "--multi-input-json", type=str, default=None,
+                help="JSON to specify multiple input files, each with a "
+                "`cmd` (command that writes the triples to stdout), "
+                "`format` (format like for the `--format` option), "
+                "`graph` (name of the graph, use `-` for the default graph), "
+                "`parallel` (parallel parsing for large files, where all "
+                "prefix declaration are at the beginning)")
         index_args["settings_json"] = arg(
                 "--settings-json", type=str, default="{}",
                 help="The `.settings.json` file for the index")
@@ -106,7 +113,7 @@ class Qleverfile:
                 help="The binary for starting the server (this requires "
                      "that you have compiled QLever on your machine)")
         server_args["host_name"] = arg(
-                "--host-name", type=str, default=f"localhost",
+                "--host-name", type=str, default="localhost",
                 help="The name of the host on which the server listens for "
                      "requests")
         server_args["port"] = arg(


### PR DESCRIPTION
So far, the input to QLever's index builder was always single input stream. Correspondingly, each Qleverfile had a variable `CAT_INPUT_FILES`, which specifies a command that writes the input to standard ouput, which is then piped into the index builder

Since https://github.com/ad-freiburg/qlever/pull/1537, QLever allows multipe input streams. The streams are parsed concurrently. For each stream separately, the following can be specified: the command that writes the input to standard output, the format, the graph of which this input should become a part, and whether the stream should be parsed in parallel (recommended for very large inputs but then all the prefix declarations must come at the beginning) or not.

In the Qleverfile, multiple input streams and their configuration can now be specifed via `MULTI_INPUT_JSON`, which takes a JSON string as value . See `qlever index --help` or `src/qlever/qleverfile.py` for information about the structure of that JSON. Using `CAT_INPUT_FILES` is still supported, but it has to be either `MULTI_INPUT_JSON` or `CAT_INPUT_FILES`. 

The Qleverfile for Wikidata has been updated to use `MULTI_INPUT_JSON` (as a showcase and because it makes sense).