### PR TITLE
Support `QLEVER_IS_RUNNING_IN_CONTAINER`

### DIFF
--- a/src/qlever/commands/setup_config.py
+++ b/src/qlever/commands/setup_config.py
@@ -39,12 +39,12 @@ class SetupConfigCommand(QleverCommand):
 
     def execute(self, args) -> bool:
         # Show a warning if `QLEVER_OVERRIDE_SYSTEM_NATIVE` is set.
-        qlever_override_system_native = environ.get("QLEVER_OVERRIDE_SYSTEM_NATIVE")
-        if qlever_override_system_native:
+        qlever_is_running_in_container = environ.get("QLEVER_IS_RUNNING_IN_CONTAINER")
+        if qlever_is_running_in_container:
             log.warning(
-                "The environment variable QLEVER_OVERRIDE_SYSTEM_NATIVE"
-                " is set, therefore the Qleverfile will be configured"
-                " to use SYSTEM = native"
+                "The environment variable `QLEVER_IS_RUNNING_IN_CONTAINER` is set, "
+                "therefore the Qleverfile is modified to use `SYSTEM = native` "
+                "(since inside the container, QLever should run natively)"
             )
             log.info("")
         # Construct the command line and show it.
@@ -53,7 +53,7 @@ class SetupConfigCommand(QleverCommand):
             f"cat {qleverfile_path}"
             f" | sed -E 's/(^ACCESS_TOKEN.*)/\\1_{get_random_string(12)}/'"
         )
-        if qlever_override_system_native:
+        if qlever_is_running_in_container:
             setup_config_cmd += (
                 " | sed -E 's/(^SYSTEM[[:space:]]*=[[:space:]]*).*/\\1native/'"
             )

--- a/src/qlever/commands/ui.py
+++ b/src/qlever/commands/ui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+from os import environ
 
 from qlever.command import QleverCommand
 from qlever.containerize import Containerize
@@ -17,46 +18,70 @@ class UiCommand(QleverCommand):
         pass
 
     def description(self) -> str:
-        return ("Launch the QLever UI web application")
+        return "Launch the QLever UI web application"
 
     def should_have_qleverfile(self) -> bool:
         return True
 
-    def relevant_qleverfile_arguments(self) -> dict[str: list[str]]:
-        return {"data": ["name"],
-                "server": ["host_name", "port"],
-                "ui": ["ui_port", "ui_config",
-                       "ui_system", "ui_image", "ui_container"]}
+    def relevant_qleverfile_arguments(self) -> dict[str : list[str]]:
+        return {
+            "data": ["name"],
+            "server": ["host_name", "port"],
+            "ui": ["ui_port", "ui_config", "ui_system", "ui_image", "ui_container"],
+        }
 
     def additional_arguments(self, subparser) -> None:
         pass
 
     def execute(self, args) -> bool:
+        # If QLEVER_OVERRIDE_DISABLE_UI is set, this command is disabled.
+        disable_ui = environ.get("QLEVER_OVERRIDE_DISABLE_UI")
+        if disable_ui:
+            log.error(
+                "The environment variable QLEVER_OVERRIDE_DISABLE_UI is set, "
+                "probably because this is running inside a container, "
+                "therefore `qlever ui` is not available"
+            )
+            log.info("")
+            if not args.show:
+                log.info(
+                    "For your information, showing the commands that are "
+                    "executed when `qlever ui` is available:"
+                )
+                log.info("")
+
         # Construct commands and show them.
         server_url = f"http://{args.host_name}:{args.port}"
         ui_url = f"http://{args.host_name}:{args.ui_port}"
         pull_cmd = f"{args.ui_system} pull -q {args.ui_image}"
-        run_cmd = f"{args.ui_system} run -d " \
-                  f"--publish {args.ui_port}:7000 " \
-                  f"--name {args.ui_container} " \
-                  f"{args.ui_image}"
-        exec_cmd = f"{args.ui_system} exec -it " \
-                   f"{args.ui_container} " \
-                   f"bash -c \"python manage.py configure " \
-                   f"{args.ui_config} {server_url}\""
-        self.show("\n".join(["Stop running containers",
-                            pull_cmd, run_cmd, exec_cmd]), only_show=args.show)
-        if args.show:
+        run_cmd = (
+            f"{args.ui_system} run -d "
+            f"--publish {args.ui_port}:7000 "
+            f"--name {args.ui_container} "
+            f"{args.ui_image}"
+        )
+        exec_cmd = (
+            f"{args.ui_system} exec -it "
+            f"{args.ui_container} "
+            f'bash -c "python manage.py configure '
+            f'{args.ui_config} {server_url}"'
+        )
+        self.show(
+            "\n".join(["Stop running containers", pull_cmd, run_cmd, exec_cmd]),
+            only_show=args.show,
+        )
+        if disable_ui or args.show:
             return False
 
         # Stop running containers.
         for container_system in Containerize.supported_systems():
-            Containerize.stop_and_remove_container(
-                    container_system, args.ui_container)
+            Containerize.stop_and_remove_container(container_system, args.ui_container)
 
         # Check if the UI port is already being used.
         if is_port_used(args.ui_port):
-            log.warning(f"It looks like the specified port for the UI ({args.ui_port}) is already in use. You can set another port in the Qleverfile in the [ui] section with the UI_PORT variable.")
+            log.warning(
+                f"It looks like the specified port for the UI ({args.ui_port}) is already in use. You can set another port in the Qleverfile in the [ui] section with the UI_PORT variable."
+            )
 
         # Try to start the QLever UI.
         try:
@@ -68,7 +93,9 @@ class UiCommand(QleverCommand):
             return False
 
         # Success.
-        log.info(f"The QLever UI should now be up at {ui_url} ..."
-                 f"You can log in as QLever UI admin with username and "
-                 f"password \"demo\"")
+        log.info(
+            f"The QLever UI should now be up at {ui_url} ..."
+            f"You can log in as QLever UI admin with username and "
+            f'password "demo"'
+        )
         return True

--- a/src/qlever/commands/ui.py
+++ b/src/qlever/commands/ui.py
@@ -35,12 +35,12 @@ class UiCommand(QleverCommand):
 
     def execute(self, args) -> bool:
         # If QLEVER_OVERRIDE_DISABLE_UI is set, this command is disabled.
-        disable_ui = environ.get("QLEVER_OVERRIDE_DISABLE_UI")
-        if disable_ui:
+        qlever_is_running_in_container = environ.get("QLEVER_IS_RUNNING_IN_CONTAINER")
+        if qlever_is_running_in_container:
             log.error(
-                "The environment variable QLEVER_OVERRIDE_DISABLE_UI is set, "
-                "probably because this is running inside a container, "
-                "therefore `qlever ui` is not available"
+                "The environment variable `QLEVER_OVERRIDE_DISABLE_UI` is set, "
+                "therefore `qlever ui` is not available (it should not be called "
+                "from inside a container)"
             )
             log.info("")
             if not args.show:
@@ -70,7 +70,7 @@ class UiCommand(QleverCommand):
             "\n".join(["Stop running containers", pull_cmd, run_cmd, exec_cmd]),
             only_show=args.show,
         )
-        if disable_ui or args.show:
+        if qlever_is_running_in_container or args.show:
             return False
 
         # Stop running containers.


### PR DESCRIPTION
With https://github.com/ad-freiburg/qlever/pull/1439, the recommended way to run QLever inside a container is to use the https://github.com/ad-freiburg/qlever-control script. Inside of the container, the environment variable `QLEVER_IS_RUNNING_IN_CONTAINER` is set, with the following two effects:

1. After `qlever setup-config <config name>`, the Qleverfile will contain the setting `SYSTEM = native` and not `SYSTEM = docker` and a warning message will be displayed that that is the case
2. When running `qlever ui`, an error message will be displayed that this command is disabled (reason: `qlever ui` runs another container, and we don't want containers inside of containers).