### PR TITLE
New option `--show-query` for command `example-queries`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Script for using the QLever SPARQL engine."
-version = "0.5.12"
+version = "0.5.13"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Script for using the QLever SPARQL engine."
-version = "0.5.11"
+version = "0.5.12"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/Qleverfiles/Qleverfile.wikidata
+++ b/src/qlever/Qleverfiles/Qleverfile.wikidata
@@ -13,7 +13,7 @@ NAME = wikidata
 
 [data]
 GET_DATA_URL      = https://dumps.wikimedia.org/wikidatawiki/entities
-GET_DATA_CMD      = curl -LROC - ${GET_DATA_URL}/latest-all.ttl.bz2 ${GET_DATA_URL}/latest-lexemes.ttl.bz2 2>&1 | tee wikidata.download-log.txt && curl -sL ${GET_DATA_URL}/dcatap.rdf | docker run -i --rm -v $$(pwd):/data stain/jena riot --syntax=RDF/XML --output=NT /dev/stdin > dcatap.nt
+GET_DATA_CMD      = curl -LRC - -O ${GET_DATA_URL}/latest-all.ttl.bz2 -O ${GET_DATA_URL}/latest-lexemes.ttl.bz2 2>&1 | tee wikidata.download-log.txt && curl -sL ${GET_DATA_URL}/dcatap.rdf | docker run -i --rm -v $$(pwd):/data stain/jena riot --syntax=RDF/XML --output=NT /dev/stdin > dcatap.nt
 DATE_WIKIDATA     = $$(date -r latest-all.ttl.bz2 +%d.%m.%Y || echo "NO_DATE")
 DATE_WIKIPEDIA    = $$(date -r wikipedia-abstracts.nt +%d.%m.%Y || echo "NO_DATE")
 DESCRIPTION       = Full Wikidata dump from ${GET_DATA_URL} (latest-all.ttl.bz2 and latest-lexemes.ttl.bz2, version ${DATE_WIKIDATA}) + English Wikipeda abstracts (version ${DATE_WIKIPEDIA}, available via schema:description)
@@ -31,11 +31,11 @@ TEXT_INDEX       = from_text_records
 
 [server]
 PORT                        = 7001
-ACCESS_TOKEN                = ${data:NAME}_3fz47hfzrbf64b
-MEMORY_FOR_QUERIES          = 40G
-CACHE_MAX_SIZE              = 30G
+ACCESS_TOKEN                = ${data:NAME}
+MEMORY_FOR_QUERIES          = 20G
+CACHE_MAX_SIZE              = 15G
 CACHE_MAX_SIZE_SINGLE_ENTRY = 5G
-TIMEOUT                     = 300s
+TIMEOUT                     = 600s
 
 [runtime]
 SYSTEM = docker

--- a/src/qlever/commands/example_queries.py
+++ b/src/qlever/commands/example_queries.py
@@ -386,11 +386,12 @@ class ExampleQueriesCommand(QleverCommand):
                     error_msg["long"] = (
                         error_msg["long"][: args.width_error_message - 3] + "..."
                     )
+                seperator_short_long = "\n" if args.show_query == "on-error" else " "
                 log.info(
                     f"{description:<{args.width_query_description}}    "
                     f"{colored('FAILED   ', 'red')}"
                     f"{colored(error_msg['short'], 'red')}"
-                    f"{'\n' if args.show_query == 'on-error' else ' '}"
+                    f"{seperator_short_long}"
                     f"{colored(error_msg['long'], 'red')}"
                 )
                 if args.show_query == "on-error":

--- a/src/qlever/commands/example_queries.py
+++ b/src/qlever/commands/example_queries.py
@@ -374,7 +374,6 @@ class ExampleQueriesCommand(QleverCommand):
                                 f'jq -r ".results.bindings | length"' f" {result_file}",
                                 return_output=True,
                             )
-                            result_size = int(result_size)
                         except Exception as e:
                             error_msg = {
                                 "short": "Malformed JSON",
@@ -390,6 +389,7 @@ class ExampleQueriesCommand(QleverCommand):
                 description = description[: args.width_query_description - 3]
                 description += "..."
             if error_msg is None:
+                result_size = int(result_size)
                 log.info(
                     f"{description:<{args.width_query_description}}  "
                     f"{time_seconds:6.2f} s  "


### PR DESCRIPTION
The new option has three choices: `always`, `never`, and `on-error`. With `never`, only the query description, time, and result size are shown for each query, as before. With `always`, the SPARQL query is shown in addition for every query. With `on-error`, it is only shown when the query failed. The query is pretty-printed.