### PR TITLE
Correct executable name

### DIFF
--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -37,6 +37,7 @@ class StartCommand(QleverCommand):
                            "timeout", "only_pso_and_pos_permutations",
                            "use_patterns", "use_text_index",
                            "warmup_cmd"],
+                "index": ["index_binary"],
                 "runtime": ["system", "image", "server_container"]}
 
     def additional_arguments(self, subparser) -> None:

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -10,7 +10,7 @@ from qlever.commands.stop import StopCommand
 from qlever.commands.warmup import WarmupCommand
 from qlever.containerize import Containerize
 from qlever.log import log
-from qlever.util import is_qlever_server_alive, run_command
+from qlever.util import is_qlever_server_alive, run_command, name_from_path
 
 
 class StartCommand(QleverCommand):
@@ -58,19 +58,21 @@ class StartCommand(QleverCommand):
                                help="Do not execute the warmup command")
 
     def execute(self, args) -> bool:
+        server_binary = name_from_path(args.server_binary)
+
         # Kill existing server with the same name if so desired.
         #
         # TODO: This is currently disabled because I never used it once over
         # the past weeks and it is not clear to me what the use case is.
         if False:  # or args.kill_existing_with_same_name:
-            args.cmdline_regex = f"^ServerMain.* -i {args.name}"
+            args.cmdline_regex = f"^{server_binary}.* -i {args.name}"
             args.no_containers = True
             StopCommand().execute(args)
             log.info("")
 
         # Kill existing server on the same port if so desired.
         if args.kill_existing_with_same_port:
-            args.cmdline_regex = f"^ServerMain.* -p {args.port}"
+            args.cmdline_regex = f"^{server_binary}.* -p {args.port}"
             args.no_containers = True
             if not StopCommand().execute(args):
                 log.error("Stopping the existing server failed")
@@ -141,7 +143,7 @@ class StartCommand(QleverCommand):
                      "--kill-existing-with-same-port`")
 
             # Show output of status command.
-            args.cmdline_regex = f"^ServerMain.* -p *{port}"
+            args.cmdline_regex = f"^{server_binary}.* -p *{port}"
             log.info("")
             StatusCommand().execute(args)
 

--- a/src/qlever/commands/status.py
+++ b/src/qlever/commands/status.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import psutil
 
 from qlever.command import QleverCommand
-from qlever.util import show_process_info
+from qlever.util import show_process_info, name_from_path
 
 
 class StatusCommand(QleverCommand):
@@ -21,7 +21,7 @@ class StatusCommand(QleverCommand):
         return False
 
     def relevant_qleverfile_arguments(self) -> dict[str: list[str]]:
-        return {}
+        return {"server": ["server_binary"], "index": ["index_binary"]}
 
     def additional_arguments(self, subparser) -> None:
         subparser.add_argument("--cmdline-regex",
@@ -30,9 +30,15 @@ class StatusCommand(QleverCommand):
                                     "line matches this regex")
 
     def execute(self, args) -> bool:
+        server_binary = name_from_path(args.server_binary)
+        index_binary = name_from_path(args.index_binary)
+        cmdline_regex = (args.cmdline_regex
+                         .replace("ServerMain", server_binary)
+                         .replace("IndexBuilderMain", index_binary))
+
         # Show action description.
         self.show(f"Show all processes on this machine where "
-                  f"the command line matches {args.cmdline_regex}"
+                  f"the command line matches {cmdline_regex}"
                   f" using Python's psutil library", only_show=args.show)
         if args.show:
             return True
@@ -41,7 +47,7 @@ class StatusCommand(QleverCommand):
         num_processes_found = 0
         for proc in psutil.process_iter():
             show_heading = num_processes_found == 0
-            process_shown = show_process_info(proc, args.cmdline_regex,
+            process_shown = show_process_info(proc, cmdline_regex,
                                               show_heading=show_heading)
             if process_shown:
                 num_processes_found += 1

--- a/src/qlever/commands/stop.py
+++ b/src/qlever/commands/stop.py
@@ -28,7 +28,8 @@ class StopCommand(QleverCommand):
     def relevant_qleverfile_arguments(self) -> dict[str: list[str]]:
         return {"data": ["name"],
                 "server": ["server_binary", "port"],
-                "runtime": ["server_container"]}
+                "runtime": ["server_container"],
+                "index": ["index_binary"]}
 
     def additional_arguments(self, subparser) -> None:
         subparser.add_argument("--cmdline-regex",

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -225,3 +225,10 @@ def format_size(bytes, suffix="B"):
         if bytes < factor:
             return f"{bytes:.2f} {unit}{suffix}"
         bytes /= factor
+
+def name_from_path(path: str) -> str:
+    """
+    Helper function that returns the name of the file from its path.
+    E.g. /qlever/ServerMain -> ServerMain
+    """
+    return Path(path).name

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -232,3 +232,4 @@ def name_from_path(path: str) -> str:
     E.g. /qlever/ServerMain -> ServerMain
     """
     return Path(path).name
+


### PR DESCRIPTION
`qlever-control` now works correctly even if the binaries don't have the default names `ServerMain` and `IndexBuilderMain`. This scenario might arise when packaging qlever, because the current binary names are not suitable for that. This PR is not quite finished yet, the string replacement on the `cmdline_regex` is still very hacky.
Fixes #101 