### PR TITLE
Remove `void.ttl.gz` from `Qleverfile.uniprot`

### DIFF
--- a/src/qlever/Qleverfiles/Qleverfile.uniprot
+++ b/src/qlever/Qleverfiles/Qleverfile.uniprot
@@ -53,8 +53,7 @@ MULTI_INPUT_JSON = [{ "cmd": "zcat {}", "graph": "http://sparql.uniprot.org/unip
                     { "cmd": "zcat ${data:TTL_DIR}/tissues.ttl.gz", "graph": "http://sparql.uniprot.org/tissues" },
                     { "cmd": "zcat ${data:TTL_DIR}/rhea.ttl.gz", "graph": "https://sparql.rhea-db.org/rhea" },
                     { "cmd": "zcat ${data:TTL_DIR}/examples_uniprot.ttl.gz", "graph": "http://sparql.uniprot.org/.well-known/sparql-examples" },
-                    { "cmd": "zcat ${data:TTL_DIR}/core.ttl.gz", "graph": "http://purl.uniprot.org/core" },
-                    { "cmd": "zcat ${data:TTL_DIR}/void.ttl.gz", "graph": "http://rdfs.org/ns/void" }]
+                    { "cmd": "zcat ${data:TTL_DIR}/core.ttl.gz", "graph": "http://purl.uniprot.org/core" }]
 SETTINGS_JSON    = { "languages-internal": [], "prefixes-external": [""], "locale": { "language": "en", "country": "US", "ignore-punctuation": true }, "ascii-prefixes-only": true, "num-triples-per-batch": 25000000 }
 STXXL_MEMORY     = 60G
 


### PR DESCRIPTION
The `void.ttl.gz` that is provided from the UniProt data distribution refers to the division of the data by file name. For the SPARQL endpoint, we want statistics by graph name. Also, the additional data (Rhea and Chebi)  should be considered. So the way to go is to generate the VoID data from the SPARQL endpoint (for example, via a tool like https://github.com/JervenBolleman/void-generator) and then add it in a dedicated graph https://sparql.uniprot.org/.well-known/void