### PR TITLE
Add option `--run-in-foreground` to `qlever start` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Script for using the QLever SPARQL engine."
-version = "0.5.14"
+version = "0.5.16"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -267,8 +267,6 @@ class StartCommand(QleverCommand):
         try:
             process = run_command(
                 start_cmd,
-                return_output=False,
-                show_output=False,
                 as_pipe=args.run_in_foreground,
             )
         except Exception as e:

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -267,7 +267,7 @@ class StartCommand(QleverCommand):
         try:
             process = run_command(
                 start_cmd,
-                as_pipe=args.run_in_foreground,
+                use_popen=args.run_in_foreground,
             )
         except Exception as e:
             log.error(f"Starting the QLever server failed ({e})")

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -22,22 +22,35 @@ class StartCommand(QleverCommand):
         pass
 
     def description(self) -> str:
-        return ("Start the QLever server (requires that you have built "
-                "an index with `qlever index` before)")
+        return (
+            "Start the QLever server (requires that you have built "
+            "an index with `qlever index` before)"
+        )
 
     def should_have_qleverfile(self) -> bool:
         return True
 
-    def relevant_qleverfile_arguments(self) -> dict[str: list[str]]:
-        return {"data": ["name", "description", "text_description"],
-                "server": ["server_binary", "host_name", "port",
-                           "access_token", "memory_for_queries",
-                           "cache_max_size", "cache_max_size_single_entry",
-                           "cache_max_num_entries", "num_threads",
-                           "timeout", "only_pso_and_pos_permutations",
-                           "use_patterns", "use_text_index",
-                           "warmup_cmd"],
-                "runtime": ["system", "image", "server_container"]}
+    def relevant_qleverfile_arguments(self) -> dict[str : list[str]]:
+        return {
+            "data": ["name", "description", "text_description"],
+            "server": [
+                "server_binary",
+                "host_name",
+                "port",
+                "access_token",
+                "memory_for_queries",
+                "cache_max_size",
+                "cache_max_size_single_entry",
+                "cache_max_num_entries",
+                "num_threads",
+                "timeout",
+                "only_pso_and_pos_permutations",
+                "use_patterns",
+                "use_text_index",
+                "warmup_cmd",
+            ],
+            "runtime": ["system", "image", "server_container"],
+        }
 
     def additional_arguments(self, subparser) -> None:
         # subparser.add_argument("--kill-existing-with-same-name",
@@ -46,16 +59,27 @@ class StartCommand(QleverCommand):
         #                        help="If a QLever server is already running "
         #                             "with the same name, kill it before "
         #                             "starting a new server")
-        subparser.add_argument("--kill-existing-with-same-port",
-                               action="store_true",
-                               default=False,
-                               help="If a QLever server is already running "
-                                    "on the same port, kill it before "
-                                    "starting a new server")
-        subparser.add_argument("--no-warmup",
-                               action="store_true",
-                               default=False,
-                               help="Do not execute the warmup command")
+        subparser.add_argument(
+            "--kill-existing-with-same-port",
+            action="store_true",
+            default=False,
+            help="If a QLever server is already running "
+            "on the same port, kill it before "
+            "starting a new server",
+        )
+        subparser.add_argument(
+            "--no-warmup",
+            action="store_true",
+            default=False,
+            help="Do not execute the warmup command",
+        )
+        subparser.add_argument(
+            "--run-in-foreground",
+            action="store_true",
+            default=False,
+            help="Run the server in the foreground "
+            "(default: run in the background with `nohup`)",
+        )
 
     def execute(self, args) -> bool:
         # Kill existing server with the same name if so desired.
@@ -78,14 +102,16 @@ class StartCommand(QleverCommand):
             log.info("")
 
         # Construct the command line based on the config file.
-        start_cmd = (f"{args.server_binary}"
-                     f" -i {args.name}"
-                     f" -j {args.num_threads}"
-                     f" -p {args.port}"
-                     f" -m {args.memory_for_queries}"
-                     f" -c {args.cache_max_size}"
-                     f" -e {args.cache_max_size_single_entry}"
-                     f" -k {args.cache_max_num_entries}")
+        start_cmd = (
+            f"{args.server_binary}"
+            f" -i {args.name}"
+            f" -j {args.num_threads}"
+            f" -p {args.port}"
+            f" -m {args.memory_for_queries}"
+            f" -c {args.cache_max_size}"
+            f" -e {args.cache_max_size_single_entry}"
+            f" -k {args.cache_max_num_entries}"
+        )
         if args.timeout:
             start_cmd += f" -s {args.timeout}"
         if args.access_token:
@@ -104,13 +130,17 @@ class StartCommand(QleverCommand):
             if not args.server_container:
                 args.server_container = f"qlever.server.{args.name}"
             start_cmd = Containerize().containerize_command(
-                    start_cmd,
-                    args.system, "run -d --restart=unless-stopped",
-                    args.image,
-                    args.server_container,
-                    volumes=[("$(pwd)", "/index")],
-                    ports=[(args.port, args.port)],
-                    working_directory="/index")
+                start_cmd,
+                args.system,
+                "run -d --restart=unless-stopped",
+                args.image,
+                args.server_container,
+                volumes=[("$(pwd)", "/index")],
+                ports=[(args.port, args.port)],
+                working_directory="/index",
+            )
+        elif args.run_in_foreground:
+            start_cmd = f"{start_cmd}"
         else:
             start_cmd = f"nohup {start_cmd} &"
 
@@ -124,9 +154,11 @@ class StartCommand(QleverCommand):
             try:
                 run_command(f"{args.server_binary} --help")
             except Exception as e:
-                log.error(f"Running \"{args.server_binary}\" failed, "
-                          f"set `--server-binary` to a different binary or "
-                          f"set `--system to a container system`")
+                log.error(
+                    f'Running "{args.server_binary}" failed, '
+                    f"set `--server-binary` to a different binary or "
+                    f"set `--system to a container system`"
+                )
                 log.info("")
                 log.info(f"The error message was: {e}")
                 return False
@@ -136,9 +168,11 @@ class StartCommand(QleverCommand):
         if is_qlever_server_alive(port):
             log.error(f"QLever server already running on port {port}")
             log.info("")
-            log.info("To kill the existing server, use `qlever stop` "
-                     "or `qlever start` with option "
-                     "--kill-existing-with-same-port`")
+            log.info(
+                "To kill the existing server, use `qlever stop` "
+                "or `qlever start` with option "
+                "--kill-existing-with-same-port`"
+            )
 
             # Show output of status command.
             args.cmdline_regex = f"^ServerMain.* -p *{port}"
@@ -148,8 +182,10 @@ class StartCommand(QleverCommand):
             return False
 
         # Remove already existing container.
-        if args.system in Containerize.supported_systems() \
-                and args.kill_existing_with_same_port:
+        if (
+            args.system in Containerize.supported_systems()
+            and args.kill_existing_with_same_port
+        ):
             try:
                 run_command(f"{args.system} rm -f {args.server_container}")
             except Exception as e:
@@ -174,8 +210,10 @@ class StartCommand(QleverCommand):
         # Tail the server log until the server is ready (note that the `exec`
         # is important to make sure that the tail process is killed and not
         # just the bash process).
-        log.info(f"Follow {args.name}.server-log.txt until the server is ready"
-                 f" (Ctrl-C stops following the log, but not the server)")
+        log.info(
+            f"Follow {args.name}.server-log.txt until the server is ready"
+            f" (Ctrl-C stops following the log, but not the server)"
+        )
         log.info("")
         tail_cmd = f"exec tail -f {args.name}.server-log.txt"
         tail_proc = subprocess.Popen(tail_cmd, shell=True)
@@ -183,12 +221,14 @@ class StartCommand(QleverCommand):
             time.sleep(1)
 
         # Set the access token if specified.
-        access_arg = f"--data-urlencode \"access-token={args.access_token}\""
+        access_arg = f'--data-urlencode "access-token={args.access_token}"'
         if args.description:
             desc = args.description
-            curl_cmd = (f"curl -Gs http://localhost:{port}/api"
-                        f" --data-urlencode \"index-description={desc}\""
-                        f" {access_arg} > /dev/null")
+            curl_cmd = (
+                f"curl -Gs http://localhost:{port}/api"
+                f' --data-urlencode "index-description={desc}"'
+                f" {access_arg} > /dev/null"
+            )
             log.debug(curl_cmd)
             try:
                 run_command(curl_cmd)
@@ -197,9 +237,11 @@ class StartCommand(QleverCommand):
                 return False
         if args.text_description:
             text_desc = args.text_description
-            curl_cmd = (f"curl -Gs http://localhost:{port}/api"
-                        f" --data-urlencode \"text-description={text_desc}\""
-                        f" {access_arg} > /dev/null")
+            curl_cmd = (
+                f"curl -Gs http://localhost:{port}/api"
+                f' --data-urlencode "text-description={text_desc}"'
+                f" {access_arg} > /dev/null"
+            )
             log.debug(curl_cmd)
             try:
                 run_command(curl_cmd)

--- a/src/qlever/commands/stop.py
+++ b/src/qlever/commands/stop.py
@@ -85,6 +85,7 @@ class StopCommand(QleverCommand):
         # Check if there is a process running on the server port using psutil.
         # NOTE: On MacOS, some of the proc's returned by psutil.process_iter()
         # no longer exist when we try to access them, so we just skip them.
+        stop_process_results = []
         for proc in psutil.process_iter():
             try:
                 pinfo = proc.as_dict(
@@ -98,7 +99,9 @@ class StopCommand(QleverCommand):
                 log.info(f"Found process {pinfo['pid']} from user "
                          f"{pinfo['username']} with command line: {cmdline}")
                 log.info("")
-                return stop_process(proc, pinfo)
+                stop_process_results.append(stop_process(proc, pinfo))
+        if len(stop_process_results) > 0:
+            return all(stop_process_results)
 
         # If no matching process found, show a message and the output of the
         # status command.

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -33,7 +33,7 @@ def run_command(
     cmd: str,
     return_output: bool = False,
     show_output: bool = False,
-    as_pipe: bool = False,
+    use_popen: bool = False,
 ) -> Optional[str | subprocess.Popen]:
     """
     Run the given command and throw an exception if the exit code is non-zero.
@@ -55,9 +55,9 @@ def run_command(
 
     # With `Popen`, the command runs in the current shell and a process object
     # is returned (which can be used, e.g., to kill the process).
-    if as_pipe:
+    if use_popen:
         if return_output:
-            raise Exception("Cannot return output if `as_pipe` is `True`")
+            raise Exception("Cannot return output if `use_popen` is `True`")
         return subprocess.Popen(f"set -o pipefail; {cmd}", **subprocess_args)
 
     # With `run`, the command runs in a subshell and the output is captured.

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -374,7 +374,14 @@ class TestStartCommand(unittest.TestCase):
         # Assert that run_command was called exactly twice with the
         # correct arguments in order
         mock_run_command.assert_has_calls(
-            [call(run_call_1), call(run_call_2)], any_order=False
+            [
+                call(run_call_1),
+                call(
+                    run_call_2,
+                    as_pipe=False,
+                ),
+            ],
+            any_order=False,
         )
         # Ensure execution was successful
         self.assertTrue(result)
@@ -586,6 +593,7 @@ class TestStartCommand(unittest.TestCase):
         args.description = "TestDescription"
         args.text_description = "TestTextDescription"
         args.access_token = "TestToken"
+        args.run_in_foreground = False
 
         # Mock server is not alive initially, then alive after starting
         mock_is_qlever_server_alive.side_effect = [False, True]
@@ -638,7 +646,7 @@ class TestStartCommand(unittest.TestCase):
         mock_run_command.assert_has_calls(
             [
                 call(run_call_1),
-                call(run_call_2),
+                call(run_call_2, as_pipe=False),
                 call(run_call_3),
                 call(run_call_4),
             ],

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -81,8 +81,8 @@ def test_construct_command_without_if():
 
 
 # Tests `wrap_command_in_container`.
-@patch("qlever.commands.start.Containerize.run_in_container")
-def test_wrap_command_in_container(mock_run_in_container):
+@patch("qlever.commands.start.Containerize.containerize_command")
+def test_wrap_command_in_container(mock_containerize_command):
     # Setup args
     args = MagicMock()
     args.name = "TestName"
@@ -92,7 +92,7 @@ def test_wrap_command_in_container(mock_run_in_container):
     args.image = None
 
     # Mock wrap_command_in_container
-    mock_run_in_container.return_value = "Test_Container_Command"
+    mock_containerize_command.return_value = "Test_Container_Command"
 
     # start_cmd before construct_command(args)
     start_cmd = "Test_start_cmd"
@@ -100,7 +100,7 @@ def test_wrap_command_in_container(mock_run_in_container):
     result = qlever.commands.start.wrap_command_in_container(args, start_cmd)
 
     # check wrap_command_in_container was called once with correct parameters
-    mock_run_in_container.assert_called_once_with(
+    mock_containerize_command.assert_called_once_with(
         start_cmd,
         args.system,
         "run -d --restart=unless-stopped",
@@ -321,6 +321,7 @@ class TestStartCommand(unittest.TestCase):
         args.system = "native"
         args.show = False
         args.no_warmup = True
+        args.run_in_foreground = False
         args.timeout = True
         args.access_token = True
         args.only_pso_and_pos_permutations = True

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -378,7 +378,7 @@ class TestStartCommand(unittest.TestCase):
                 call(run_call_1),
                 call(
                     run_call_2,
-                    as_pipe=False,
+                    use_popen=False,
                 ),
             ],
             any_order=False,
@@ -646,7 +646,7 @@ class TestStartCommand(unittest.TestCase):
         mock_run_command.assert_has_calls(
             [
                 call(run_call_1),
-                call(run_call_2, as_pipe=False),
+                call(run_call_2, use_popen=False),
                 call(run_call_3),
                 call(run_call_4),
             ],


### PR DESCRIPTION
With the new option `--run-in-foreground`, the `qlever start` command now remains in the foreground as long as the process that runs the QLever server is alive, following the log. Addresses #98 