### PR TITLE
New `extract-queries` command + other improvements

### DIFF
--- a/src/qlever/commands/example_queries.py
+++ b/src/qlever/commands/example_queries.py
@@ -259,6 +259,12 @@ class ExampleQueriesCommand(QleverCommand):
             log.error(f"Failed to get example queries: {e}")
             return False
 
+        # We want the width of the query description to be an uneven number (in
+        # case we have to truncated it, in which case we want to have a " ... "
+        # in the middle).
+        width_query_description_half = args.width_query_description // 2
+        width_query_description = 2 * width_query_description_half + 1
+
         # Launch the queries one after the other and for each print: the
         # description, the result size (number of rows), and the query
         # processing time (seconds).
@@ -470,13 +476,16 @@ class ExampleQueriesCommand(QleverCommand):
                 Path(result_file).unlink(missing_ok=True)
 
             # Print description, time, result in tabular form.
-            if len(description) > args.width_query_description:
-                description = description[: args.width_query_description - 3]
-                description += "..."
+            if len(description) > width_query_description:
+                description = (
+                    description[: width_query_description_half - 2]
+                    + " ... "
+                    + description[-width_query_description_half + 2 :]
+                )
             if error_msg is None:
                 result_size = int(result_size)
                 log.info(
-                    f"{description:<{args.width_query_description}}  "
+                    f"{description:<{width_query_description}}  "
                     f"{time_seconds:6.2f} s  "
                     f"{result_size:>{args.width_result_size},}"
                 )
@@ -498,7 +507,7 @@ class ExampleQueriesCommand(QleverCommand):
                     "\n" if args.show_query == "on-error" else "  "
                 )
                 log.info(
-                    f"{description:<{args.width_query_description}}    "
+                    f"{description:<{width_query_description}}    "
                     f"{colored('FAILED   ', 'red')}"
                     f"{colored(error_msg['short'], 'red'):>{args.width_result_size}}"
                     f"{seperator_short_long}"
@@ -532,19 +541,19 @@ class ExampleQueriesCommand(QleverCommand):
             description = f"TOTAL   for {n} {query_or_queries}"
             log.info("")
             log.info(
-                f"{description:<{args.width_query_description}}  "
+                f"{description:<{width_query_description}}  "
                 f"{total_query_time:6.2f} s  "
                 f"{total_result_size:>14,}"
             )
             description = f"AVERAGE for {n} {query_or_queries}"
             log.info(
-                f"{description:<{args.width_query_description}}  "
+                f"{description:<{width_query_description}}  "
                 f"{average_query_time:6.2f} s  "
                 f"{average_result_size:>14,}"
             )
             description = f"MEDIAN  for {n} {query_or_queries}"
             log.info(
-                f"{description:<{args.width_query_description}}  "
+                f"{description:<{width_query_description}}  "
                 f"{median_query_time:6.2f} s  "
                 f"{median_result_size:>14,}"
             )
@@ -558,7 +567,7 @@ class ExampleQueriesCommand(QleverCommand):
                 num_failed_string += "  [all]"
             log.info(
                 colored(
-                    f"{description:<{args.width_query_description}}  "
+                    f"{description:<{width_query_description}}  "
                     f"{num_failed:>24}",
                     "red",
                 )

--- a/src/qlever/commands/extract_queries.py
+++ b/src/qlever/commands/extract_queries.py
@@ -70,7 +70,6 @@ class ExtractQueriesCommand(QleverCommand):
                 # Skipe line that start with #
                 if not re.match(log_line_regex, line):
                     if not re.match(r"^\s*#", line):
-                        print(line, end="")
                         line = re.sub(r" #.*", "", line)
                         query.append(line)
                 else:

--- a/src/qlever/commands/extract_queries.py
+++ b/src/qlever/commands/extract_queries.py
@@ -32,6 +32,12 @@ class ExtractQueriesCommand(QleverCommand):
             " (default: `Log extract`)",
         )
         subparser.add_argument(
+            "--log-file",
+            type=str,
+            help="Name of the log file to extract queries from"
+            " (default: `<name>.server-log.txt`)",
+        )
+        subparser.add_argument(
             "--output-file",
             type=str,
             default="log-queries.txt",
@@ -40,7 +46,10 @@ class ExtractQueriesCommand(QleverCommand):
 
     def execute(self, args) -> bool:
         # Show what the command does.
-        log_file_name = f"{args.name}.server-log.txt"
+        if args.log_file is not None:
+            log_file_name = args.log_file
+        else:
+            log_file_name = f"{args.name}.server-log.txt"
         self.show(
             f"Extract SPARQL queries from `{log_file_name}`"
             f" and write them to `{args.output_file}`",
@@ -74,7 +83,9 @@ class ExtractQueriesCommand(QleverCommand):
             # A new query in the log.
             if "Processing the following SPARQL query" in line:
                 query = []
-                query_index = description_base_count.get(description_base, 0) + 1
+                query_index = (
+                    description_base_count.get(description_base, 0) + 1
+                )
                 description_base_count[description_base] = query_index
                 continue
             # If we have started a query: extend until we meet the next log

--- a/src/qlever/commands/extract_queries.py
+++ b/src/qlever/commands/extract_queries.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import re
+
+from qlever.command import QleverCommand
+from qlever.log import log
+
+
+class ExtractQueriesCommand(QleverCommand):
+    """
+    Class for executing the `extract-queries` command.
+    """
+
+    def __init__(self):
+        pass
+
+    def description(self) -> str:
+        return "Extract all SPARQL queries from the server log"
+
+    def should_have_qleverfile(self) -> bool:
+        return True
+
+    def relevant_qleverfile_arguments(self) -> dict[str : list[str]]:
+        return {"data": ["name"]}
+
+    def additional_arguments(self, subparser) -> None:
+        subparser.add_argument(
+            "--description-format",
+            type=str,
+            default="Log query {i}",
+            help="Prefix for the description of the extracted queries"
+            " (default: `Log query {i}`)",
+        )
+        subparser.add_argument(
+            "--output-file",
+            type=str,
+            default="log-queries.txt",
+            help="Output file for the extracted queries (default: `log-queries.txt`)",
+        )
+
+    def execute(self, args) -> bool:
+        # Show what the command does.
+        log_file_name = f"{args.name}.server-log.txt"
+        self.show(
+            f"Extract SPARQL queries from `{log_file_name}`"
+            f" and write them to `{args.output_file}`",
+            only_show=args.show,
+        )
+        if args.show:
+            return True
+
+        # Regex for log entries of the form
+        # 2025-01-14 04:47:44.950 - INFO
+        log_line_regex = (
+            r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) - [A-Z]+:"
+        )
+
+        # Read the log file line by line.
+        log_file = open(log_file_name, "r")
+        queries_file = open(args.output_file, "w")
+        query = None
+        query_index = 0
+        tsv_line_short_width = 150
+        for line in log_file:
+            if "Processing the following SPARQL query" in line:
+                query = []
+                query_index += 1
+                continue
+            if query is not None:
+                # Skipe line that start with #
+                if not re.match(log_line_regex, line):
+                    if not re.match(r"^\s*#", line):
+                        print(line, end="")
+                        line = re.sub(r" #.*", "", line)
+                        query.append(line)
+                else:
+                    query = re.sub(r"\s+", " ", "\n".join(query)).strip()
+                    description = args.description_format.format(i=query_index)
+                    tsv_line = f"{description}\t{query}"
+                    tsv_line_short = (
+                        tsv_line
+                        if len(tsv_line) < tsv_line_short_width
+                        else tsv_line[:tsv_line_short_width] + "..."
+                    )
+                    log.info(tsv_line_short)
+                    print(tsv_line, file=queries_file)
+                    query = None
+        log_file.close()
+        queries_file.close()
+        return True

--- a/src/qlever/commands/settings.py
+++ b/src/qlever/commands/settings.py
@@ -28,6 +28,7 @@ class SettingsCommand(QleverCommand):
 
     def additional_arguments(self, subparser) -> None:
         all_keys = [
+            "always-multiply-unions",
             "cache-max-num-entries",
             "cache-max-size",
             "cache-max-size-single-entry",


### PR DESCRIPTION
The new `extract-queries` command extracts all queries from the server log and writes it into a TSV file that can be processed using the `example-queries` command. If the server log contains lines matching `Alive check with message "..."`, the message is used as base name for the query descriptions. For each query with that base name `Query #<index>` is appended to the description.

In this context, the following small improvements for the `example-queries` command (items 1, 2, 3, 4) and the `settings` command (item 5) were made:

1. The default for `--download_or_count` is now the more natural `download` (was: `count`).
2. The option `--accept` now has two more choices `application/qlever-results+json` and `AUTO`, where the later picks the accept header automatically from the query type
3. There is a new option `--add-query-type-to-description`
4. Long query descriptions are now truncated in the middle, that is shown as `Beginnig ... end`
5. For the runtime parameters supported by the settings command, there is now also `always-mulitply-unions`