### PR TITLE
Fail if ulimit fails, use lower limit

### DIFF
--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -218,7 +218,7 @@ class IndexCommand(QleverCommand):
         # large number of open files is allowed).
         total_file_size = get_total_file_size(shlex.split(args.input_files))
         if total_file_size > 1e10:
-            index_cmd = f"ulimit -Sn 1048576; {index_cmd}"
+            index_cmd = f"ulimit -Sn 524288 && {index_cmd}"
 
         # Run the command in a container (if so desired).
         if args.system in Containerize.supported_systems():

--- a/src/qlever/qlever_old.py
+++ b/src/qlever/qlever_old.py
@@ -523,7 +523,7 @@ class Actions:
             self.config["index"]["file_names"].split()
         )
         if total_file_size > 10:
-            cmdline = f"ulimit -Sn 1048576; {cmdline}"
+            cmdline = f"ulimit -Sn 524288 && {cmdline}"
 
         # If we are using Docker, run the command in a Docker container.
         # Here is how the shell script does it:

--- a/test/qlever/commands/test_index_execute.py
+++ b/test/qlever/commands/test_index_execute.py
@@ -252,7 +252,7 @@ class TestIndexCommand(unittest.TestCase):
 
         # Assertions
         expected_index_cmd = (
-            f"ulimit -Sn 1048576; {args.cat_input_files} | {args.index_binary}"
+            f"ulimit -Sn 524288 && {args.cat_input_files} | {args.index_binary}"
             f" -i {args.name} -s {args.name}.settings.json"
             f" -F {args.format} -f -"
             f" | tee {args.name}.index-log.txt"


### PR DESCRIPTION
- Use `&&` instead of `;` to chain `ulimit` with next commands. In case of `ulimit` failing, it's probably better to fail right away and not after hours of indexing.
- Reduce the file descriptor limit to 2^19 - that seems to be a default hard limit on my system. I managed to index wikidata-truthy with that value, I'm not sure if that's enough in general.