### PR TITLE
Add `PERSIST_UPDATES` option for command `start`

### DIFF
--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -39,6 +39,7 @@ class IndexCommand(QleverCommand):
                 "parallel_parsing",
                 "settings_json",
                 "index_binary",
+                "persist_updates",
                 "only_pso_and_pos_permutations",
                 "ulimit",
                 "use_patterns",
@@ -211,6 +212,8 @@ class IndexCommand(QleverCommand):
             return False
 
         # Add remaining options.
+        if args.persist_updates:
+            index_cmd += " --persist-updates"
         if args.only_pso_and_pos_permutations:
             index_cmd += " --only-pso-and-pos-permutations --no-patterns"
         if not args.use_patterns:

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -39,7 +39,6 @@ class IndexCommand(QleverCommand):
                 "parallel_parsing",
                 "settings_json",
                 "index_binary",
-                "persist_updates",
                 "only_pso_and_pos_permutations",
                 "ulimit",
                 "use_patterns",
@@ -212,8 +211,6 @@ class IndexCommand(QleverCommand):
             return False
 
         # Add remaining options.
-        if args.persist_updates:
-            index_cmd += " --persist-updates"
         if args.only_pso_and_pos_permutations:
             index_cmd += " --only-pso-and-pos-permutations --no-patterns"
         if not args.use_patterns:

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -30,6 +30,8 @@ def construct_command(args) -> str:
         start_cmd += f" -s {args.timeout}"
     if args.access_token:
         start_cmd += f" -a {args.access_token}"
+    if args.persist_updates:
+        start_cmd += " --persist-updates"
     if args.only_pso_and_pos_permutations:
         start_cmd += " --only-pso-and-pos-permutations"
     if not args.use_patterns:
@@ -148,6 +150,7 @@ class StartCommand(QleverCommand):
                 "cache_max_num_entries",
                 "num_threads",
                 "timeout",
+                "persist_updates",
                 "only_pso_and_pos_permutations",
                 "use_patterns",
                 "use_text_index",

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -134,6 +134,13 @@ class Qleverfile:
             "large enough to contain the end of at least one statement "
             "(default: 10M)",
         )
+        index_args["persist-updates"] = arg(
+            "--persist-updates",
+            action="store_true",
+            default=False,
+            help="Persist updates to the index (write updates to disk and "
+            "read them back in when restarting the server)",
+        )
         index_args["only_pso_and_pos_permutations"] = arg(
             "--only-pso-and-pos-permutations",
             action="store_true",

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -134,13 +134,6 @@ class Qleverfile:
             "large enough to contain the end of at least one statement "
             "(default: 10M)",
         )
-        index_args["persist-updates"] = arg(
-            "--persist-updates",
-            action="store_true",
-            default=False,
-            help="Persist updates to the index (write updates to disk and "
-            "read them back in when restarting the server)",
-        )
         index_args["only_pso_and_pos_permutations"] = arg(
             "--only-pso-and-pos-permutations",
             action="store_true",
@@ -248,6 +241,13 @@ class Qleverfile:
             type=int,
             default=8,
             help="The number of threads used for query processing",
+        )
+        server_args["persist_updates"] = arg(
+            "--persist-updates",
+            action="store_true",
+            default=False,
+            help="Persist updates to the index (write updates to disk and "
+            "read them back in when restarting the server)",
         )
         server_args["only_pso_and_pos_permutations"] = arg(
             "--only-pso-and-pos-permutations",

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -18,6 +18,7 @@ def test_construct_command_with_if():
     args.cache_max_size_single_entry = "124M"
     args.cache_max_num_entries = 1000
     args.timeout = True
+    args.persist_updates = False
     args.access_token = True
     args.only_pso_and_pos_permutations = True
     args.use_patterns = False
@@ -58,6 +59,7 @@ def test_construct_command_without_if():
     args.cache_max_size_single_entry = "124M"
     args.cache_max_num_entries = 1000
     args.timeout = False
+    args.persist_updates = False
     args.access_token = False
     args.only_pso_and_pos_permutations = False
     args.use_patterns = True
@@ -323,6 +325,7 @@ class TestStartCommand(unittest.TestCase):
         args.no_warmup = True
         args.run_in_foreground = False
         args.timeout = True
+        args.persist_updates = False
         args.access_token = True
         args.only_pso_and_pos_permutations = True
         args.use_patterns = False

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -38,6 +38,7 @@ class TestStartCommand(unittest.TestCase):
                     "cache_max_num_entries",
                     "num_threads",
                     "timeout",
+                    "persist_updates",
                     "only_pso_and_pos_permutations",
                     "use_patterns",
                     "use_text_index",


### PR DESCRIPTION
This is the accompanying change for the `persists-updates` option introduced by https://github.com/ad-freiburg/qlever/pull/1903