### PR TITLE
Fix encoding issues for `urllib<2.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
  "Topic :: Database :: Front-Ends"
 ]
 
-dependencies = [ "psutil", "termcolor", "argcomplete", "pyyaml", "rdflib", "requests-sse", "tqdm", "requests" ]
+dependencies = [ "psutil", "termcolor", "argcomplete", "pyyaml", "rdflib", "requests-sse", "tqdm" ]
 
 [project.urls]
 Github = "https://github.com/ad-freiburg/qlever"

--- a/src/qlever/commands/update_wikidata.py
+++ b/src/qlever/commands/update_wikidata.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 from enum import Enum, auto
 
 import rdflib.term
-import requests
 import requests_sse
 from rdflib import Graph
 from termcolor import colored
@@ -604,8 +603,7 @@ class UpdateWikidataCommand(QleverCommand):
             if args.verbose == "yes":
                 log.info(colored(curl_cmd, "blue"))
 
-            # Run it (using `curl` for batch size up to 1000, otherwise
-            # `requests`).
+            # Run the update using `curl`.
             try:
                 result = run_command(curl_cmd, return_output=True)
                 with open(f"update.result.{batch_count}", "w") as f:


### PR DESCRIPTION
## Changes

Explicitly encode the `data` as `utf-8` to avoid problems with `urllib<2.0.0`. Also list `requests` as a dependency because we use it directly.

## Explanation

When using `requests` encoding errors could occur under the following conditions:

- `urllib3<2.0.0`
- the `data` parameter is a `str`
- the data contains non `latin1`/`ISO 8859-1` characters

Before `2.0.0` `urllib3` used `http.client` to actually send the requests which encodes `str` data as `latin1` (where the error message is from). From `urllib>=2.0.0` a custom client is used which encodes `str` data as `utf-8`. `bytes` data is not encoded again.