### PR TITLE
Add QLever native binaries version number to qlever --version output

### DIFF
--- a/src/qlever/config.py
+++ b/src/qlever/config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import os
 import traceback
-from importlib.metadata import version
 from pathlib import Path
 
 import argcomplete
@@ -12,6 +11,7 @@ from termcolor import colored
 from qlever import command_objects, engine_name, script_name
 from qlever.log import log, log_levels
 from qlever.qleverfile import Qleverfile
+from qlever.util import build_version_string
 
 
 # Simple exception class for configuration errors (the class need not do
@@ -180,13 +180,14 @@ class QleverConfig:
                 f"This is the {script_name} command line tool, "
                 f"it's all you need to work with {engine_name}",
                 attrs=["bold"],
-            )
+            ),
+            formatter_class=argparse.RawDescriptionHelpFormatter,
         )
         if script_name == "qlever":
             parser.add_argument(
                 "--version",
                 action="version",
-                version=f"%(prog)s {version('qlever')}",
+                version=build_version_string(),
             )
         add_qleverfile_option(parser)
         subparsers = parser.add_subparsers(dest='command')

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -332,6 +332,24 @@ def is_server_alive(url: str) -> bool:
         return False
 
 
+def get_image_version_string() -> str:
+    image_name = "docker.io/adfreiburg/qlever"
+    image_version_cmd = r'images --format "{{.Tag}}" ' + image_name
+    is_docker = bool(shutil.which("docker"))
+    if is_docker:
+        image_version_cmd = "docker " + image_version_cmd
+    is_podman = bool(shutil.which("podman"))
+    if is_podman:
+        image_version_cmd = "podman " + image_version_cmd
+    if not is_docker and not is_podman:
+        return f"{image_name} image: Both docker and podman NOT FOUND on PATH"
+    try:
+        version_str = run_command(image_version_cmd, return_output=True)
+        return f"{image_name} image: {version_str.strip()}"
+    except Exception as e:
+        return f"{image_name} image: ERROR in determining version - {e}"
+
+
 def get_binary_version_string(binary_name: str) -> str:
     if not shutil.which(binary_name):
         return f"{binary_name}: NOT FOUND on PATH"
@@ -351,4 +369,5 @@ def build_version_string() -> str:
     parts.append(f"{script_name}: {version(script_name)}\n")
     for binary in ["IndexBuilderMain", "ServerMain"]:
         parts.append(get_binary_version_string(binary))
+    parts.append(get_image_version_string())
     return "\n".join(parts)

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -9,11 +9,13 @@ import socket
 import string
 import subprocess
 from datetime import date, datetime
+from importlib.metadata import version
 from pathlib import Path
 from typing import Any, Optional
 
 import psutil
 
+from qlever import script_name
 from qlever.log import log
 
 
@@ -328,3 +330,25 @@ def is_server_alive(url: str) -> bool:
         return True
     except Exception:
         return False
+
+
+def get_binary_version_string(binary_name: str) -> str:
+    if not shutil.which(binary_name):
+        return f"{binary_name}: NOT FOUND on PATH"
+    try:
+        binary_version_str = run_command(
+            f"{binary_name} --version", return_output=True
+        )
+        if not binary_version_str.startswith(f"QLever {binary_name}"):
+            return f"{binary_name}: VERSION information not available!"
+        return binary_version_str.strip()
+    except Exception as e:
+        return f"{binary_name}: ERROR in determining version - {e}"
+
+
+def build_version_string() -> str:
+    parts = []
+    parts.append(f"{script_name}: {version(script_name)}\n")
+    for binary in ["IndexBuilderMain", "ServerMain"]:
+        parts.append(get_binary_version_string(binary))
+    return "\n".join(parts)


### PR DESCRIPTION
Add IndexBuilderMain and ServerMain binary version number to qlever --version output. Handle the case when the binaries are not on path or the version text is not available.