### PR TITLE
Fix evaluation web app files missing from installed package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ bugtracker = "https://github.com/ad-freiburg/qlever/issues"
 "qlever" = "qlever.qlever_main:main"
 
 [tool.setuptools]
-package-data = { "qlever" = ["Qleverfiles/*"] }
+package-data = { "qlever" = ["Qleverfiles/*", "evaluation/www/*"] }
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/qlever/commands/benchmark_queries.py
+++ b/src/qlever/commands/benchmark_queries.py
@@ -474,7 +474,7 @@ def get_result_yml_query_record(
     if result_size is None and isinstance(result, dict):
         results = f"{result['short']}: {result['long']}"
         headers = []
-    if result_size and isinstance(result, str):
+    if result_size is not None and isinstance(result, str):
         record["result_size"] = result_size
         result_size = (
             max_result_size if result_size > max_result_size else result_size

--- a/src/qlever/commands/serve_evaluation_app.py
+++ b/src/qlever/commands/serve_evaluation_app.py
@@ -4,6 +4,7 @@ import json
 import statistics
 from functools import partial
 from http.server import HTTPServer, SimpleHTTPRequestHandler
+from importlib.resources import as_file, files
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote
@@ -12,8 +13,6 @@ import yaml
 
 from qlever.command import QleverCommand
 from qlever.log import log
-
-EVAL_DIR = Path(__file__).parent.parent / "evaluation"
 
 # Default values for the performance statistics returned by the
 # /yaml_data API endpoint and consumed by the evaluation web app.
@@ -228,16 +227,17 @@ class ServeEvaluationAppCommand(QleverCommand):
 
     def execute(self, args) -> bool:
         yaml_dir = Path(args.results_dir)
-        handler = partial(
-            CustomHTTPRequestHandler,
-            directory=EVAL_DIR,
-            yaml_dir=yaml_dir,
-            title=args.title_overview_page,
-        )
-        httpd = HTTPServer((args.host, args.port), handler)
-        log.info(
-            f"Performance Comparison Web App is available at "
-            f"http://{args.host}:{args.port}/www"
-        )
-        httpd.serve_forever()
+        with as_file(files("qlever") / "evaluation") as eval_dir:
+            handler = partial(
+                CustomHTTPRequestHandler,
+                directory=str(eval_dir),
+                yaml_dir=yaml_dir,
+                title=args.title_overview_page,
+            )
+            httpd = HTTPServer((args.host, args.port), handler)
+            log.info(
+                f"Performance Comparison Web App is available at "
+                f"http://{args.host}:{args.port}/www"
+            )
+            httpd.serve_forever()
         return True

--- a/src/qlever/evaluation/www/details.js
+++ b/src/qlever/evaluation/www/details.js
@@ -67,8 +67,8 @@ function getQueryDetails(performanceData, kb, engine) {
         const runtime = Number(queryData.runtime_info.client_time.toFixed(2));
         queryDetails.runtime.push(runtime);
 
-        // A query is considered failed if results is a string (error message) or no headers
-        const failed = typeof queryData.results === "string" || (queryData.headers?.length ?? 0) === 0;
+        // A query is considered failed if results is a string (error message) and no headers
+        const failed = typeof queryData.results === "string" && (queryData.headers?.length ?? 0) === 0;
         queryDetails.failed.push(failed);
 
         const resultSize = queryData.result_size ?? 0;
@@ -212,12 +212,16 @@ let exec_tree_listener = null;
  */
 function updateExecTreeTab(rowData) {
     const runtime_info = rowData?.runtime_info;
+    document.querySelector("#result-tree").innerHTML = "";
+    document.querySelector("#meta-info").innerHTML = "";
+    const treeDiv = document.querySelector("#result-tree-div");
+    document.querySelector("#exec-tree-tab-pane > div.alert-info").classList.add("d-none");
+    treeDiv.classList.remove("d-none");
     if (runtime_info?.query_execution_tree) {
-        for (const div of document.querySelectorAll("#exec-tree-tab-pane div")) {
+        for (const div of treeDiv.querySelectorAll("div")) {
             if (div.classList.contains("alert-info")) div.classList.add("d-none");
             else div.classList.remove("d-none");
         }
-        document.querySelector("#result-tree").innerHTML = "";
         const exec_tree_tab = document.querySelector("#exec-tree-tab");
 
         // Remove previous listener if exists
@@ -230,10 +234,11 @@ function updateExecTreeTab(rowData) {
         };
         exec_tree_tab.addEventListener("shown.bs.tab", exec_tree_listener, { once: true });
     } else {
-        // No execution tree available - show appropriate message
-        document.querySelector("#exec-tree-tab-pane div.alert-info").classList.add("d-none");
-        document.querySelector("#result-tree-div").classList.remove("d-none");
-        document.querySelector("#result-tree-div div.alert-info").classList.remove("d-none");
+        // No execution tree available - show only the alert message
+        for (const div of treeDiv.querySelectorAll("div")) {
+            if (div.classList.contains("alert-info")) div.classList.remove("d-none");
+            else div.classList.add("d-none");
+        }
     }
 }
 
@@ -408,7 +413,7 @@ function updateDetailsPage(performanceData, kb, engine, kbAdditionalData) {
         onRowSelected: (event) => {
             // Prevent re-processing if same row is selected
             const query = Array.isArray(selectedRow) ? selectedRow[0].query : null;
-            if (event.api.getSelectedRows()[0].query === query) return;
+            if (event.api.getSelectedRows()[0]?.query === query) return;
             selectedRow = event.api.getSelectedRows();
             onRuntimeRowSelected(event, performanceData, kb, engine);
         },

--- a/src/qlever/evaluation/www/index.html
+++ b/src/qlever/evaluation/www/index.html
@@ -410,8 +410,9 @@
                     <div class="alert alert-info mt-4">Please select a query from the Query Runtimes table!</div>
                     <div id="result-tree-div" class="mt-4">
                         <div class="alert alert-info mt-4">
-                            Execution Tree is only available for QLever with accept header
-                            application/qlever-results+json!
+                            No execution tree information available for this query.
+                            (Execution trees require QLever with accept header
+                            application/qlever-results+json.)
                         </div>
                         <!-- Tree meta info and zoom controls -->
                         <div class="d-flex justify-content-between align-items-start mb-2">


### PR DESCRIPTION
The `src/qlever/evaluation/` directory (which contains the Javascript, HTML, and CSS for the evaluation web app) was not considered in the `pyproject.toml`, so `qlever serve-evaluation-app` failed to find its static assets when installed via `pip install qlever`. This is now fixed. In particular, fixes #284

On the side, two minor fixes: Successful queries returning zero rows are no longer marked red in the "Detailed Results per Query" table. Switching to a query without an execution tree no longer leaves the previous query's tree, meta-info, and zoom controls on the screen