### PR TITLE
Set minimum Python version to `3.10`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["pypy3.9", "pypy3.10", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["pypy3.10", "pypy3.11", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{matrix.python-version}}
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 keywords = ["Graph database", "Triplestore", "Knowledge graphs", "SPARQL", "RDF"]
 


### PR DESCRIPTION
Set the minimum Python version to `3.10` in `pyproject.toml`, and update the unit test workflow (drop old versions and add new versions). Resolves ad-freiburg/qlever#2847

NOTE: Python 3.10 is chosen for the following reasons. It is the oldest version that is still officially supported with updates and the oldest version that we package for. Note that `importlib.resources.as_file` and `importlib.resources.files` in `serve_evaluation_app.py` require 3.9, and `platform.freedesktop_os_release` in `system_info.py` requires 3.10. Support for older versions is likely possible if needed. For example, `platform.freedesktop_os_release` could be replaced with the `distro` package.