### PR TITLE
Support `--preload-materialized-views` in `qlever start` command

### DIFF
--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 import time
 from pathlib import Path
 
@@ -45,6 +46,15 @@ def construct_command(args) -> str:
         start_cmd += " --no-patterns"
     if args.use_text_index == "yes":
         start_cmd += " -t"
+    preload_materialized_views = vars(args).get(
+        "preload_materialized_views"
+    )
+    if preload_materialized_views:
+        start_cmd += " --preload-materialized-views"
+        start_cmd += "".join(
+            f" {shlex.quote(view_name)}"
+            for view_name in preload_materialized_views
+        )
     start_cmd += f" > {args.name}.server-log.txt 2>&1"
     return start_cmd
 
@@ -148,6 +158,7 @@ class StartCommand(QleverCommand):
                 "only_pso_and_pos_permutations",
                 "use_patterns",
                 "use_text_index",
+                "preload_materialized_views",
                 "warmup_cmd",
             ],
             "runtime": [

--- a/src/qlever/config.py
+++ b/src/qlever/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import traceback
 from importlib.metadata import version
 from pathlib import Path
@@ -106,7 +107,12 @@ class QleverConfig:
                         section, arg_name, fallback=None
                     )
                     if qleverfile_value is not None:
-                        kwargs_copy["default"] = qleverfile_value
+                        qleverfile_default = qleverfile_value
+                        if "nargs" in kwargs_copy:
+                            qleverfile_default = shlex.split(
+                                qleverfile_value
+                            )
+                        kwargs_copy["default"] = qleverfile_default
                         kwargs_copy["required"] = False
                         escaped_value = qleverfile_value.replace("%", "%%")
                         kwargs_copy["help"] += (

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -347,6 +347,14 @@ class Qleverfile:
             help="Whether to use the text index (requires that one was "
             "built, see `qlever index`)",
         )
+        server_args["preload_materialized_views"] = arg(
+            "-l",
+            "--preload-materialized-views",
+            nargs="+",
+            default=None,
+            help="Names of one or more materialized views to preload on "
+            "startup",
+        )
         server_args["warmup_cmd"] = arg(
             "--warmup-cmd",
             type=str,

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -24,6 +24,7 @@ def test_construct_command_with_if():
     args.only_pso_and_pos_permutations = True
     args.use_patterns = "no"
     args.use_text_index = "yes"
+    args.preload_materialized_views = ["view-1", "view-2"]
 
     # Execute the function
     result = qlever.commands.start.construct_command(args)
@@ -42,6 +43,7 @@ def test_construct_command_with_if():
         " --only-pso-and-pos-permutations"
         " --no-patterns"
         " -t"
+        " --preload-materialized-views view-1 view-2"
         f" > {args.name}.server-log.txt 2>&1"
     )
     assert result == start_command
@@ -65,6 +67,7 @@ def test_construct_command_without_if():
     args.only_pso_and_pos_permutations = False
     args.use_patterns = True
     args.use_text_index = "no"
+    args.preload_materialized_views = None
 
     # Execute the function
     result = qlever.commands.start.construct_command(args)
@@ -351,6 +354,7 @@ class TestStartCommand(unittest.TestCase):
         args.only_pso_and_pos_permutations = True
         args.use_patterns = "no"
         args.use_text_index = "yes"
+        args.preload_materialized_views = None
 
         # Configure Path mock so the log file wait loop is skipped
         self._mock_log_file(mock_path_cls, args.name)

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -2,6 +2,7 @@ import argparse
 import unittest
 
 from qlever.commands.start import StartCommand
+from qlever.qleverfile import Qleverfile
 
 
 class TestStartCommand(unittest.TestCase):
@@ -42,6 +43,7 @@ class TestStartCommand(unittest.TestCase):
                     "only_pso_and_pos_permutations",
                     "use_patterns",
                     "use_text_index",
+                    "preload_materialized_views",
                     "warmup_cmd",
                 ],
                 "runtime": [
@@ -84,3 +86,12 @@ class TestStartCommand(unittest.TestCase):
         # Test that the help text for --no-warmup is correctly set
         argument_help = subparser._group_actions[-3].help
         self.assertEqual(argument_help, "Do not execute the warmup command")
+
+    def test_preload_materialized_views_qleverfile_argument(self):
+        args, kwargs = Qleverfile.all_arguments()["server"][
+            "preload_materialized_views"
+        ]
+
+        self.assertEqual(args, ("-l", "--preload-materialized-views"))
+        self.assertEqual(kwargs["nargs"], "+")
+        self.assertEqual(kwargs["default"], None)


### PR DESCRIPTION
Adds support for the `--preload-materialized-views` option in the `qlever start` command and `PRELOAD_MATERIALIZED_VIEWS` in the `[server]` section of the `Qleverfile`.

Reflects <https://github.com/ad-freiburg/qlever/pull/2659>