### PR TITLE
Support `--metrics-log` in `qlever start` command

### DIFF
--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -46,6 +46,8 @@ def construct_command(args) -> str:
         start_cmd += " --no-patterns"
     if args.use_text_index == "yes":
         start_cmd += " -t"
+    if args.metrics_log == "no":
+        start_cmd += " --no-metrics-log"
     preload_materialized_views = vars(args).get("preload_materialized_views")
     if preload_materialized_views:
         start_cmd += " --preload-materialized-views"
@@ -156,6 +158,7 @@ class StartCommand(QleverCommand):
                 "only_pso_and_pos_permutations",
                 "use_patterns",
                 "use_text_index",
+                "metrics_log",
                 "preload_materialized_views",
                 "warmup_cmd",
             ],

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -340,6 +340,13 @@ class Qleverfile:
             help="Whether to use the patterns precomputed during the index "
             "build (see `qlever index --help` for their utility)",
         )
+        server_args["metrics_log"] = arg(
+            "--metrics-log",
+            choices=["yes", "no"],
+            default="yes",
+            help="Whether to produce the per-query metrics log, a JSONL log of "
+            "query start/end events (`.metrics-log.jsonl`)",
+        )
         server_args["use_text_index"] = arg(
             "--use-text-index",
             choices=["yes", "no"],

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -43,6 +43,7 @@ class TestStartCommand(unittest.TestCase):
                     "only_pso_and_pos_permutations",
                     "use_patterns",
                     "use_text_index",
+                    "metrics_log",
                     "preload_materialized_views",
                     "warmup_cmd",
                 ],


### PR DESCRIPTION
Adds support for the `--metrics-log` option (`yes` and `no`) in the `qlever start` command and `METRICS_LOG` in the `[server]` section of the `Qleverfile`. It defaults to `yes`, matching the server's default of producing a per-query metrics log.

When set to `no`, `qlever start` passes `--no-metrics-log` to the server binary, which then does not write the `.metrics-log.jsonl` file of query start/end events.

Reflects <https://github.com/ad-freiburg/qlever/pull/2871>