### PR TITLE
Speed up `monitor-queries` log reading

### DIFF
--- a/src/qlever/commands/monitor_queries.py
+++ b/src/qlever/commands/monitor_queries.py
@@ -61,10 +61,9 @@ class MonitorQueriesCommand(QleverCommand):
         subparser.add_argument(
             "--refresh",
             type=float,
-            default=REFRESH_MIN_S,
+            default=1,
             help="Live view screen refresh interval in seconds, between"
-            f" {REFRESH_MIN_S} and {REFRESH_MAX_S}"
-            f" (default = {REFRESH_MIN_S})",
+            f" {REFRESH_MIN_S} and {REFRESH_MAX_S} (default = 1)",
         )
 
     def execute(self, args) -> bool:

--- a/src/qlever/monitor_queries/app.py
+++ b/src/qlever/monitor_queries/app.py
@@ -18,7 +18,10 @@ from qlever.monitor_queries.live_data import (
     find_active_queries,
     load_completed_history,
 )
-from qlever.monitor_queries.log_reader import read_first_timestamp
+from qlever.monitor_queries.log_reader import (
+    open_log_buffer,
+    read_first_timestamp,
+)
 from qlever.monitor_queries.util import clipboard_install_hint, copy_text
 from qlever.monitor_queries.views.historic import HistoricScreen
 from qlever.monitor_queries.views.live import LiveScreen
@@ -91,10 +94,10 @@ class MonitorQueriesApp(App):
         """
         if self.log_start_ms is not None:
             return
-        with self.log_file.open("rb") as log_stream:
-            self.log_start_ms = read_first_timestamp(
-                log_stream, self.log_file.stat().st_size
-            )
+        with open_log_buffer(self.log_file) as buf:
+            if buf is None:
+                return
+            self.log_start_ms = read_first_timestamp(buf)
 
     def on_mount(self) -> None:
         """Boot the live engine, then open the Live screen."""

--- a/src/qlever/monitor_queries/historic_data.py
+++ b/src/qlever/monitor_queries/historic_data.py
@@ -17,7 +17,6 @@ from qlever.monitor_queries.log_reader import (
     CLIENT_IP_KEY,
     HEAD_BYTES,
     CompletedQuery,
-    extract_qid_ip_query,
     line_query_contains,
     load_sparql_snippet_at,
     offset_for_ts,
@@ -260,13 +259,17 @@ def filter_by_text(
     if not filters.has_text_filter():
         return queries
     ip_search = (filters.client_ip_substr or "").lower()
-    sparql_search = (filters.sparql_substr or "").lower()
-    # bytes.lower() only folds ASCII, so non-ASCII search text skips
-    # the raw search and decodes every line instead.
+    # An ASCII term matches case-insensitively; a term with any
+    # non-ASCII char matches exactly, since bytes.lower() only folds
+    # ASCII.
     raw_search = None
-    if filters.sparql_substr is not None and filters.sparql_substr.isascii():
+    ignore_case = True
+    if filters.sparql_substr is not None:
+        ignore_case = filters.sparql_substr.isascii()
         escaped = json.dumps(filters.sparql_substr, ensure_ascii=False)[1:-1]
-        raw_search = escaped.lower().encode()
+        raw_search = (
+            escaped.lower().encode() if ignore_case else escaped.encode()
+        )
     ordered = sorted(queries, key=lambda query: query.start_line_offset)
     kept = []
     with open_log_buffer(log_path) as buf:
@@ -288,17 +291,10 @@ def filter_by_text(
                 line_end = buf.find(b"\n", offset)
                 if line_end == -1:
                     line_end = len(buf)
-                if raw_search is not None:
-                    if not line_query_contains(
-                        buf, offset, line_end, raw_search
-                    ):
-                        continue
-                else:
-                    # Non-ASCII search text: bytes cannot case-fold
-                    # it, so decode the line and compare as strings.
-                    _, _, sparql = extract_qid_ip_query(buf[offset:line_end])
-                    if sparql_search not in sparql.lower():
-                        continue
+                if not line_query_contains(
+                    buf, offset, line_end, raw_search, ignore_case
+                ):
+                    continue
             kept.append(query)
     return kept
 

--- a/src/qlever/monitor_queries/historic_data.py
+++ b/src/qlever/monitor_queries/historic_data.py
@@ -7,6 +7,7 @@ mode at render time. A window change reruns the scan; a mode change
 reuses the scanned list.
 """
 
+import json
 from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
@@ -14,8 +15,10 @@ from typing import NamedTuple
 
 from qlever.monitor_queries.log_reader import (
     CLIENT_IP_KEY,
+    HEAD_BYTES,
     CompletedQuery,
     extract_qid_ip_query,
+    line_query_contains,
     load_sparql_snippet_at,
     offset_for_ts,
     open_log_buffer,
@@ -247,14 +250,23 @@ def filter_by_text(
 ) -> list[LoggedQuery]:
     """Keep queries whose start-line text passes the text filters.
 
-    Reads each surviving start line in ascending offset order and runs
-    the case-insensitive substring tests, retaining no text. The client
-    IP is sliced from the line bytes (IPs never escape), so only a
-    SPARQL filter decodes the line, and only for IP-test survivors.
-    Returns the same list when no text filter is set.
+    Both tests are case-insensitive substring checks. The client IP
+    test reads only the first HEAD_BYTES of the line. The SPARQL test
+    escapes the search text like the log itself and searches the raw
+    line bytes, so no line is decoded; only non-ASCII search text
+    falls back to decoding every line. Returns the same list when no
+    text filter is set.
     """
     if not filters.has_text_filter():
         return queries
+    ip_search = (filters.client_ip_substr or "").lower()
+    sparql_search = (filters.sparql_substr or "").lower()
+    # bytes.lower() only folds ASCII, so non-ASCII search text skips
+    # the raw search and decodes every line instead.
+    raw_search = None
+    if filters.sparql_substr is not None and filters.sparql_substr.isascii():
+        escaped = json.dumps(filters.sparql_substr, ensure_ascii=False)[1:-1]
+        raw_search = escaped.lower().encode()
     ordered = sorted(queries, key=lambda query: query.start_line_offset)
     kept = []
     with open_log_buffer(log_path) as buf:
@@ -262,16 +274,31 @@ def filter_by_text(
             return queries
         for query in ordered:
             offset = query.start_line_offset
-            end = buf.find(b"\n", offset)
-            line = buf[offset:] if end == -1 else buf[offset:end]
             if filters.client_ip_substr is not None:
-                client_ip = slice_string_value(line, CLIENT_IP_KEY) or ""
-                if filters.client_ip_substr.lower() not in client_ip.lower():
+                # Bounded so a short line cannot spill the next line's
+                # fields into the test.
+                head_end = buf.find(b"\n", offset, offset + HEAD_BYTES)
+                if head_end == -1:
+                    head_end = offset + HEAD_BYTES
+                head = buf[offset:head_end]
+                client_ip = slice_string_value(head, CLIENT_IP_KEY) or ""
+                if ip_search not in client_ip.lower():
                     continue
             if filters.sparql_substr is not None:
-                _, _, sparql = extract_qid_ip_query(line)
-                if filters.sparql_substr.lower() not in sparql.lower():
-                    continue
+                line_end = buf.find(b"\n", offset)
+                if line_end == -1:
+                    line_end = len(buf)
+                if raw_search is not None:
+                    if not line_query_contains(
+                        buf, offset, line_end, raw_search
+                    ):
+                        continue
+                else:
+                    # Non-ASCII search text: bytes cannot case-fold
+                    # it, so decode the line and compare as strings.
+                    _, _, sparql = extract_qid_ip_query(buf[offset:line_end])
+                    if sparql_search not in sparql.lower():
+                        continue
             kept.append(query)
     return kept
 

--- a/src/qlever/monitor_queries/historic_data.py
+++ b/src/qlever/monitor_queries/historic_data.py
@@ -16,7 +16,7 @@ from qlever.monitor_queries.log_reader import (
     CLIENT_IP_KEY,
     CompletedQuery,
     extract_qid_ip_query,
-    load_sparql_at,
+    load_sparql_snippet_at,
     offset_for_ts,
     open_log_buffer,
     pair_start_end_events,
@@ -284,10 +284,12 @@ def load_query_details(
     """Fill the details cache for any of the given start-line offsets.
 
     The `qid`, `client_ip`, and SPARQL text live on each query's start
-    line, which `read_window` did not read. Offsets already cached are
-    reused; the rest are read in one pass, opening the file only when
-    something is missing. The cache is scoped to one window so a sort
-    or mode change repaints from memory.
+    line, which `read_window` did not read. Only the start of the query
+    is read, since the table truncates it; the SparqlPane reads the full
+    text on demand. Offsets already cached are reused; the rest are read
+    in one pass, opening the file only when something is missing. The
+    cache is scoped to one window so a sort or mode change repaints from
+    memory.
     """
     missing = [
         offset for offset in offsets if offset not in query_details_cache
@@ -297,7 +299,9 @@ def load_query_details(
             if buf is None:
                 return
             for offset in missing:
-                query_details_cache[offset] = load_sparql_at(buf, offset)
+                query_details_cache[offset] = load_sparql_snippet_at(
+                    buf, offset
+                )
 
 
 def load_query_details_for_rows(

--- a/src/qlever/monitor_queries/historic_data.py
+++ b/src/qlever/monitor_queries/historic_data.py
@@ -18,6 +18,7 @@ from qlever.monitor_queries.log_reader import (
     extract_qid_ip_query,
     load_sparql_at,
     offset_for_ts,
+    open_log_buffer,
     pair_start_end_events,
     scan_range,
     slice_string_value,
@@ -73,13 +74,12 @@ def read_window(
     `pad_ms` of `log_end_ms` and the log itself is fresh
     (`now_ms - log_end_ms <= pad_ms`); otherwise `"orphaned"`.
     """
-    with log_path.open("rb") as log_stream:
-        file_size = log_path.stat().st_size
-        lo_offset = offset_for_ts(
-            log_stream, window_start_ms - pad_ms, file_size
-        )
-        hi_bound = offset_for_ts(log_stream, window_end_ms + pad_ms, file_size)
-        events = scan_range(log_stream, lo_offset, hi_bound, should_cancel)
+    with open_log_buffer(log_path) as buf:
+        if buf is None:
+            return []
+        lo_offset = offset_for_ts(buf, window_start_ms - pad_ms)
+        hi_bound = offset_for_ts(buf, window_end_ms + pad_ms)
+        events = scan_range(buf, lo_offset, hi_bound, should_cancel)
         completed, still_open = pair_start_end_events(events)
 
         queries = []
@@ -257,10 +257,13 @@ def filter_by_text(
         return queries
     ordered = sorted(queries, key=lambda query: query.start_line_offset)
     kept = []
-    with log_path.open("rb") as log_stream:
+    with open_log_buffer(log_path) as buf:
+        if buf is None:
+            return queries
         for query in ordered:
-            log_stream.seek(query.start_line_offset)
-            line = log_stream.readline()
+            offset = query.start_line_offset
+            end = buf.find(b"\n", offset)
+            line = buf[offset:] if end == -1 else buf[offset:end]
             if filters.client_ip_substr is not None:
                 client_ip = slice_string_value(line, CLIENT_IP_KEY) or ""
                 if filters.client_ip_substr.lower() not in client_ip.lower():
@@ -290,11 +293,11 @@ def load_query_details(
         offset for offset in offsets if offset not in query_details_cache
     ]
     if missing:
-        with log_path.open("rb") as log_stream:
+        with open_log_buffer(log_path) as buf:
+            if buf is None:
+                return
             for offset in missing:
-                query_details_cache[offset] = load_sparql_at(
-                    log_stream, offset
-                )
+                query_details_cache[offset] = load_sparql_at(buf, offset)
 
 
 def load_query_details_for_rows(

--- a/src/qlever/monitor_queries/live_data.py
+++ b/src/qlever/monitor_queries/live_data.py
@@ -21,6 +21,7 @@ from qlever.monitor_queries.log_reader import (
     load_sparql_at,
     normalize_status,
     offset_for_ts,
+    open_log_buffer,
     pair_start_end_events,
     read_last_timestamp,
     scan_range,
@@ -154,23 +155,21 @@ def find_active_queries(
     complete line, or 0 when the log holds none.
     """
     state = LiveState()
-    with log_path.open("rb") as log_stream:
-        file_size = log_path.stat().st_size
-        eof_ts = read_last_timestamp(log_stream, file_size)
+    with open_log_buffer(log_path) as buf:
+        if buf is None:
+            return (state, 0, 0)
+        file_size = len(buf)
+        eof_ts = read_last_timestamp(buf)
         if eof_ts is None:
             return (state, file_size, 0)
 
         state.latest_event_ms = eof_ts
-        lo_offset = offset_for_ts(
-            log_stream, eof_ts - window_pad_ms, file_size
-        )
-        events = scan_range(log_stream, lo_offset, file_size)
+        lo_offset = offset_for_ts(buf, eof_ts - window_pad_ms)
+        events = scan_range(buf, lo_offset, file_size)
         _, still_open = pair_start_end_events(events)
 
         for qid, (start_ms, start_line_offset) in still_open.items():
-            _, client_ip, sparql = load_sparql_at(
-                log_stream, start_line_offset
-            )
+            _, client_ip, sparql = load_sparql_at(buf, start_line_offset)
             state.active[qid] = ActiveQuery(
                 start_ms=start_ms,
                 end_ms=None,
@@ -199,12 +198,14 @@ def load_completed_history(
     line in range and can be paired. Pairs that ended before the hour
     are then dropped, matching the deque's end_ms retention.
     """
-    with log_path.open("rb") as log_stream:
+    with open_log_buffer(log_path) as buf:
+        if buf is None:
+            return
         oldest_wanted_ms = now_ms() - LIVE_HORIZON_MS
         scan_start_offset = offset_for_ts(
-            log_stream, oldest_wanted_ms - window_pad_ms, cut_offset
+            buf, oldest_wanted_ms - window_pad_ms
         )
-        events = scan_range(log_stream, scan_start_offset, cut_offset)
+        events = scan_range(buf, scan_start_offset, cut_offset)
         paired, _ = pair_start_end_events(events)
         older_completions = [
             query for query in paired if query.end_ms >= oldest_wanted_ms

--- a/src/qlever/monitor_queries/log_reader.py
+++ b/src/qlever/monitor_queries/log_reader.py
@@ -449,7 +449,10 @@ def load_sparql_snippet_at(
     qid = slice_string_value(head, QID_KEY) or ""
     client_ip = slice_string_value(head, CLIENT_IP_KEY) or ""
 
-    value_start = buf.find(QUERY_KEY, line_offset) + len(QUERY_KEY)
+    key_at = buf.find(QUERY_KEY, line_offset)
+    if key_at == -1:
+        return qid, client_ip, ""
+    value_start = key_at + len(QUERY_KEY)
     limit = value_start + SNIPPET_BYTES
     # Bounded so a large query is never scanned past the cap.
     end = buf.find(b"\n", line_offset, limit + 2)

--- a/src/qlever/monitor_queries/log_reader.py
+++ b/src/qlever/monitor_queries/log_reader.py
@@ -390,6 +390,36 @@ def extract_qid_ip_query(line_bytes: bytes) -> tuple[str, str, str]:
     return obj["qid"], obj.get("client-ip", ""), obj["query"]
 
 
+def line_query_contains(
+    buf: LogBuffer, line_offset: int, line_end: int, raw_search: bytes
+) -> bool:
+    """Whether the start line's query text contains the raw search.
+
+    `raw_search` must be lowercased and JSON-escaped like the log
+    itself. Only the query value is searched: it starts after the
+    `query` key and ends before the line's closing quote and brace. A
+    hit preceded by an odd number of backslashes starts inside an
+    escape sequence, so it is not a real occurrence and the search
+    moves on to the next hit.
+    """
+    value_start = buf.find(QUERY_KEY, line_offset, line_end)
+    if value_start == -1:
+        return False
+    value_start += len(QUERY_KEY)
+    value = buf[value_start : max(line_end - 2, value_start)].lower()
+    position = value.find(raw_search)
+    while position != -1:
+        backslashes = 0
+        probe = position - 1
+        while probe >= 0 and value[probe : probe + 1] == b"\\":
+            backslashes += 1
+            probe -= 1
+        if backslashes % 2 == 0:
+            return True
+        position = value.find(raw_search, position + 1)
+    return False
+
+
 def load_sparql_at(buf: LogBuffer, line_offset: int) -> tuple[str, str, str]:
     """Return (qid, client_ip, sparql) for the start line at line_offset.
 

--- a/src/qlever/monitor_queries/log_reader.py
+++ b/src/qlever/monitor_queries/log_reader.py
@@ -1,8 +1,12 @@
 """Pure primitives for reading the query metrics log"""
 
 import json
+import mmap
+import os
 from collections.abc import Callable, Iterator
-from typing import BinaryIO, NamedTuple
+from contextlib import contextmanager
+from pathlib import Path
+from typing import NamedTuple
 
 TS_PREFIX = b'{"ts-ms":'
 EVENT_KEY = b'"event":"'
@@ -14,6 +18,28 @@ STATUS_KEY = b'"status":"'
 STATUS_SET = frozenset({"ok", "failed", "cancelled", "timeout"})
 
 UNKNOWN_STATUS = "unknown"
+
+# The log buffer: an mmap in normal use, plain bytes in tests.
+LogBuffer = mmap.mmap | bytes
+
+# Bytes read from the start of a line to get its header fields
+# (timestamp, event, qid), skipping the large query text after them.
+HEAD_BYTES = 256
+
+
+@contextmanager
+def open_log_buffer(path: Path) -> Iterator[mmap.mmap | None]:
+    """Open the log file for reading and yield it as a buffer.
+
+    Yields None if the file is empty, since you cannot mmap an empty
+    file. Callers should check `if buf is None` before using it.
+    """
+    with path.open("rb") as f:
+        if os.fstat(f.fileno()).st_size == 0:
+            yield None
+            return
+        with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as buf:
+            yield buf
 
 
 class CompletedQuery(NamedTuple):
@@ -139,81 +165,58 @@ def parse_line_fallback(
     return (ts_ms, event, qid, normalize_status(status))
 
 
-def next_whole_line(
-    log_stream: BinaryIO, probe: int, file_size: int
-) -> tuple[int, int] | None:
-    """Find the first complete line starting at or after `probe`.
+def next_whole_line(buf: LogBuffer, probe: int) -> tuple[int, int] | None:
+    """Find the first whole line at or after `probe`.
 
-    A raw probe usually lands mid-line, so we align to the start of the
-    next whole line. Returns (line_start, ts_ms), or None when `probe`
-    falls in the file's trailing partial line or past EOF.
+    A probe usually lands mid-line, so we move to the next line start.
+    Returns (line_start, ts_ms), or None if there is no whole line
+    after `probe`.
     """
-    if probe >= file_size:
+    if probe >= len(buf):
         return None
     if probe == 0:
         line_start = 0
-        log_stream.seek(0)
     else:
-        log_stream.seek(probe)
-        # Discard the partial line the probe landed in; the next read
-        # then starts on a whole line.
-        log_stream.readline()
-        line_start = log_stream.tell()
+        # Skip the partial line the probe landed in.
+        newline = buf.find(b"\n", probe)
+        if newline == -1:
+            return None
+        line_start = newline + 1
 
-    line = log_stream.readline()
-    # An empty read or a line with no terminating newline is the file's
-    # trailing partial line, not a complete record.
-    if not line.endswith(b"\n"):
+    end = buf.find(b"\n", line_start)
+    # No newline left means this is the file's trailing partial line.
+    if end == -1:
         return None
-    ts_ms = peek_ts_ms(line)
+    ts_ms = peek_ts_ms(buf[line_start : line_start + HEAD_BYTES])
     if ts_ms is None:
         return None
     return (line_start, ts_ms)
 
 
-def read_first_timestamp(log_stream: BinaryIO, file_size: int) -> int | None:
-    """Return the ts_ms of the first complete line, or None.
-
-    Scans forward from the start of the file, skipping malformed
-    lines, and returns the first ts_ms that parses.
-    """
-    if file_size == 0:
+def read_first_timestamp(buf: LogBuffer) -> int | None:
+    """Return the timestamp of the first whole line, or None."""
+    end = buf.find(b"\n")
+    if end == -1:
         return None
-    log_stream.seek(0)
-    while True:
-        line = log_stream.readline()
-        # No newline means EOF or a partial line: nothing complete left.
-        if not line.endswith(b"\n"):
-            return None
-        ts_ms = peek_ts_ms(line)
+    return peek_ts_ms(buf[:HEAD_BYTES])
+
+
+def read_last_timestamp(buf: LogBuffer) -> int | None:
+    """Return the timestamp of the last whole line, or None.
+
+    Walks backward from the end, skipping a trailing partial line and
+    any malformed lines.
+    """
+    end = buf.rfind(b"\n")
+    if end == -1:
+        return None
+    while end > 0:
+        start = buf.rfind(b"\n", 0, end) + 1
+        ts_ms = peek_ts_ms(buf[start : start + HEAD_BYTES])
         if ts_ms is not None:
             return ts_ms
-
-
-def read_last_timestamp(log_stream: BinaryIO, file_size: int) -> int | None:
-    """Return the ts_ms of the last complete line, or None.
-
-    Reads a 32KB tail buffer and walks its lines backward, returning
-    the first ts_ms that parses. A trailing partial line is skipped by
-    its missing newline; a leading mid-line fragment is skipped because
-    it does not start with the ts_ms prefix. Doubles the buffer and
-    retries if nothing parses, capped at the whole file.
-    """
-    if file_size == 0:
-        return None
-    tail_bytes = 32 * 1024
-    while True:
-        probe = max(0, file_size - tail_bytes)
-        log_stream.seek(probe)
-        for line in reversed(log_stream.readlines()):
-            if not line.endswith(b"\n"):
-                continue
-            ts_ms = peek_ts_ms(line)
-            if ts_ms is not None:
-                return ts_ms
-        if probe == 0:
-            return None
-        tail_bytes *= 2
+        end = start - 1
+    return None
 
 
 GALLOP_START = 128 * 1024
@@ -222,7 +225,7 @@ GALLOP_START = 128 * 1024
 CANCEL_CHECK_BYTES = 8 * 1024 * 1024
 
 
-def offset_for_ts(log_stream: BinaryIO, target_ms: int, file_size: int) -> int:
+def offset_for_ts(buf: LogBuffer, target_ms: int) -> int:
     """Find where to start reading so a forward read sees every line
     at or after target_ms.
 
@@ -231,7 +234,8 @@ def offset_for_ts(log_stream: BinaryIO, target_ms: int, file_size: int) -> int:
     few extra older lines. Returns 0 if target_ms is at or before the
     first line, and a spot near the end if it is past the last line.
     """
-    first = next_whole_line(log_stream, 0, file_size)
+    file_size = len(buf)
+    first = next_whole_line(buf, 0)
     if first is None:
         return 0
     first_start, first_ts = first
@@ -248,7 +252,7 @@ def offset_for_ts(log_stream: BinaryIO, target_ms: int, file_size: int) -> int:
         probe = file_size - step
         if probe <= before_target:
             break
-        found = next_whole_line(log_stream, probe, file_size)
+        found = next_whole_line(buf, probe)
         if found is None:
             step *= 2
             continue
@@ -263,7 +267,7 @@ def offset_for_ts(log_stream: BinaryIO, target_ms: int, file_size: int) -> int:
     # result never sits past the first matching line.
     while after_target - before_target > 1:
         mid = (before_target + after_target) // 2
-        found = next_whole_line(log_stream, mid, file_size)
+        found = next_whole_line(buf, mid)
         if found is None:
             after_target = mid
             continue
@@ -282,7 +286,7 @@ def offset_for_ts(log_stream: BinaryIO, target_ms: int, file_size: int) -> int:
 
 
 def scan_range(
-    log_stream: BinaryIO,
+    buf: LogBuffer,
     lo_offset: int,
     hi_bound: int,
     should_cancel: Callable[[], bool] | None = None,
@@ -294,26 +298,31 @@ def scan_range(
     hi_bound is included; a trailing line without a newline is left for a
     later read. Malformed lines are skipped.
 
+    Only the line's head is parsed, so the large query text is never
+    read. The rare line that needs more falls back to a full parse.
+
     When should_cancel is given, it is polled every CANCEL_CHECK_BYTES and
     the scan returns early if it is true. That yields a partial stream, so
     a caller that cancels must re-check before trusting the result.
     """
-    log_stream.seek(lo_offset)
     offset = lo_offset
     next_cancel_check = lo_offset + CANCEL_CHECK_BYTES
-    for line in log_stream:
-        if offset > hi_bound:
-            return
-        if not line.endswith(b"\n"):
+    while offset <= hi_bound:
+        newline = buf.find(b"\n", offset)
+        # No newline left means a trailing partial line; leave it.
+        if newline == -1:
             return
         if should_cancel is not None and offset >= next_cancel_check:
             if should_cancel():
                 return
             next_cancel_check = offset + CANCEL_CHECK_BYTES
-        parsed = parse_line(line) or parse_line_fallback(line)
+        head = buf[offset : min(newline, offset + HEAD_BYTES)]
+        parsed = parse_line(head)
+        if parsed is None:
+            parsed = parse_line_fallback(buf[offset:newline])
         if parsed is not None:
             yield (parsed, offset)
-        offset += len(line)
+        offset = newline + 1
 
 
 def pair_start_end_events(
@@ -369,14 +378,13 @@ def extract_qid_ip_query(line_bytes: bytes) -> tuple[str, str, str]:
     return (obj["qid"], obj.get("client-ip", ""), obj["query"])
 
 
-def load_sparql_at(
-    log_stream: BinaryIO, line_offset: int
-) -> tuple[str, str, str]:
+def load_sparql_at(buf: LogBuffer, line_offset: int) -> tuple[str, str, str]:
     """Return (qid, client_ip, sparql) for the start line at line_offset.
 
     Used by callers that have only the offset, not the line bytes:
     find_active_queries on survivors (qid already known, ignored), and
     Historic on displayed rows (needs all three for the SparqlPane).
     """
-    log_stream.seek(line_offset)
-    return extract_qid_ip_query(log_stream.readline())
+    end = buf.find(b"\n", line_offset)
+    line = buf[line_offset:] if end == -1 else buf[line_offset:end]
+    return extract_qid_ip_query(line)

--- a/src/qlever/monitor_queries/log_reader.py
+++ b/src/qlever/monitor_queries/log_reader.py
@@ -13,6 +13,7 @@ EVENT_KEY = b'"event":"'
 QID_KEY = b'"qid":"'
 CLIENT_IP_KEY = b'"client-ip":"'
 STATUS_KEY = b'"status":"'
+QUERY_KEY = b'"query":"'
 
 # Statuses the server writes; anything else maps to UNKNOWN_STATUS.
 STATUS_SET = frozenset({"ok", "failed", "cancelled", "timeout"})
@@ -25,6 +26,10 @@ LogBuffer = mmap.mmap | bytes
 # Bytes read from the start of a line to get its header fields
 # (timestamp, event, qid), skipping the large query text after them.
 HEAD_BYTES = 256
+
+# Query bytes read for the table, where the text is truncated to ~200
+# display chars. The extra leaves room for escapes and whitespace.
+SNIPPET_BYTES = 256
 
 
 @contextmanager
@@ -122,12 +127,12 @@ def parse_line(
         return None
 
     if event == "start":
-        return (ts_ms, event, qid, None)
+        return ts_ms, event, qid, None
 
     status = slice_string_value(line_bytes, STATUS_KEY)
     if status is None:
         return None
-    return (ts_ms, event, qid, normalize_status(status))
+    return ts_ms, event, qid, normalize_status(status)
 
 
 def parse_line_fallback(
@@ -157,12 +162,12 @@ def parse_line_fallback(
         return None
 
     if event == "start":
-        return (ts_ms, event, qid, None)
+        return ts_ms, event, qid, None
 
     status = obj.get("status")
     if not isinstance(status, str):
         return None
-    return (ts_ms, event, qid, normalize_status(status))
+    return ts_ms, event, qid, normalize_status(status)
 
 
 def next_whole_line(buf: LogBuffer, probe: int) -> tuple[int, int] | None:
@@ -190,7 +195,7 @@ def next_whole_line(buf: LogBuffer, probe: int) -> tuple[int, int] | None:
     ts_ms = peek_ts_ms(buf[line_start : line_start + HEAD_BYTES])
     if ts_ms is None:
         return None
-    return (line_start, ts_ms)
+    return line_start, ts_ms
 
 
 def read_first_timestamp(buf: LogBuffer) -> int | None:
@@ -241,6 +246,13 @@ def offset_for_ts(buf: LogBuffer, target_ms: int) -> int:
     first_start, first_ts = first
     if first_ts >= target_ms:
         return 0
+
+    # Target past the last line: start there, skip the gallop.
+    last_newline = buf.rfind(b"\n")
+    last_start = buf.rfind(b"\n", 0, last_newline) + 1
+    last_ts = peek_ts_ms(buf[last_start : last_start + HEAD_BYTES])
+    if last_ts is not None and target_ms > last_ts:
+        return last_start
 
     # Gallop backward from the end, doubling the step until a probed
     # line is old enough (ts <= target). before_target brackets the
@@ -321,7 +333,7 @@ def scan_range(
         if parsed is None:
             parsed = parse_line_fallback(buf[offset:newline])
         if parsed is not None:
-            yield (parsed, offset)
+            yield parsed, offset
         offset = newline + 1
 
 
@@ -360,7 +372,7 @@ def pair_start_end_events(
                 start_line_offset=start_line_offset,
             )
         )
-    return (completed_queries, still_open)
+    return completed_queries, still_open
 
 
 def extract_qid_ip_query(line_bytes: bytes) -> tuple[str, str, str]:
@@ -374,8 +386,8 @@ def extract_qid_ip_query(line_bytes: bytes) -> tuple[str, str, str]:
     try:
         obj = json.loads(line_bytes)
     except (ValueError, TypeError):
-        return ("", "", "")
-    return (obj["qid"], obj.get("client-ip", ""), obj["query"])
+        return "", "", ""
+    return obj["qid"], obj.get("client-ip", ""), obj["query"]
 
 
 def load_sparql_at(buf: LogBuffer, line_offset: int) -> tuple[str, str, str]:
@@ -388,3 +400,34 @@ def load_sparql_at(buf: LogBuffer, line_offset: int) -> tuple[str, str, str]:
     end = buf.find(b"\n", line_offset)
     line = buf[line_offset:] if end == -1 else buf[line_offset:end]
     return extract_qid_ip_query(line)
+
+
+def load_sparql_snippet_at(
+    buf: LogBuffer, line_offset: int
+) -> tuple[str, str, str]:
+    """Read qid, client-ip, and the start of the query.
+
+    The table only shows a short, truncated query, so reading a large
+    one in full is wasted. This reads just the start of it instead.
+    """
+    head = buf[line_offset : line_offset + HEAD_BYTES]
+    qid = slice_string_value(head, QID_KEY) or ""
+    client_ip = slice_string_value(head, CLIENT_IP_KEY) or ""
+
+    value_start = buf.find(QUERY_KEY, line_offset) + len(QUERY_KEY)
+    limit = value_start + SNIPPET_BYTES
+    # Bounded so a large query is never scanned past the cap.
+    end = buf.find(b"\n", line_offset, limit + 2)
+    if end == -1:
+        value = buf[value_start:limit]
+    else:
+        # Drop the line's closing quote and brace.
+        value = buf[value_start : end - 2]
+
+    # The cap can split an escape, so retry shorter until it decodes.
+    while value:
+        try:
+            return qid, client_ip, json.loads(b'"' + value + b'"')
+        except ValueError:
+            value = value[:-1]
+    return qid, client_ip, ""

--- a/src/qlever/monitor_queries/log_reader.py
+++ b/src/qlever/monitor_queries/log_reader.py
@@ -391,22 +391,27 @@ def extract_qid_ip_query(line_bytes: bytes) -> tuple[str, str, str]:
 
 
 def line_query_contains(
-    buf: LogBuffer, line_offset: int, line_end: int, raw_search: bytes
+    buf: LogBuffer,
+    line_offset: int,
+    line_end: int,
+    raw_search: bytes,
+    ignore_case: bool,
 ) -> bool:
     """Whether the start line's query text contains the raw search.
 
-    `raw_search` must be lowercased and JSON-escaped like the log
-    itself. Only the query value is searched: it starts after the
-    `query` key and ends before the line's closing quote and brace. A
-    hit preceded by an odd number of backslashes starts inside an
-    escape sequence, so it is not a real occurrence and the search
-    moves on to the next hit.
+    `raw_search` must be JSON-escaped like the log. When `ignore_case`
+    is true both it and the value are lowercased for a case-insensitive
+    match; when false both stay as-is for an exact match. A hit
+    preceded by an odd number of backslashes sits inside an escape
+    sequence, so it is skipped.
     """
     value_start = buf.find(QUERY_KEY, line_offset, line_end)
     if value_start == -1:
         return False
     value_start += len(QUERY_KEY)
-    value = buf[value_start : max(line_end - 2, value_start)].lower()
+    value = buf[value_start : max(line_end - 2, value_start)]
+    if ignore_case:
+        value = value.lower()
     position = value.find(raw_search)
     while position != -1:
         backslashes = 0

--- a/src/qlever/monitor_queries/monitor.tcss
+++ b/src/qlever/monitor_queries/monitor.tcss
@@ -75,7 +75,7 @@ MetricsRow {
     margin-left: 1;
 }
 
-LiveQueryTable.stale, MetricsRow.stale {
+QueryTable.stale, MetricsRow.stale {
     color: $text-muted;
 }
 
@@ -107,6 +107,16 @@ QueryTable {
 QueryTable > .datatable--cursor {
     background: $secondary;
     color: $text;
+}
+
+QueryTable.stale > .datatable--cursor {
+    background: $secondary-muted;
+    color: $text-muted;
+}
+
+QueryTable.stale > .datatable--header {
+    background: $panel-darken-1;
+    color: $text-muted;
 }
 
 /* active-filter readout, just above the table; hidden until a filter is set */

--- a/src/qlever/monitor_queries/util.py
+++ b/src/qlever/monitor_queries/util.py
@@ -21,11 +21,28 @@ def format_clock(ms: int) -> str:
     return datetime.fromtimestamp(ms / 1000).strftime("%H:%M:%S")
 
 
+def format_seconds(seconds: float) -> str:
+    """Format seconds to 3 shown digits, no unit suffix.
+
+    The leading zero counts as a digit, so it is dropped below 0.1
+    (.032) to keep exactly three digits on screen.
+    """
+    if seconds >= 10.0:
+        text = f"{seconds:.1f}"
+    elif seconds >= 0.1:
+        text = f"{seconds:.2f}"
+    elif seconds == 0:
+        text = "0"
+    else:
+        text = f"{seconds:.3f}"[1:]
+    return text
+
+
 def format_duration(ms: int) -> str:
-    """Render a duration in seconds to one decimal, or '?' when unknown."""
+    """Render a duration in seconds to 3 significant figures, or '?'."""
     if ms < 0:
         return "?"
-    return f"{ms / 1000:.1f}s"
+    return f"{format_seconds(ms / 1000)}s"
 
 
 def truncate(text: str, max_len: int) -> str:

--- a/src/qlever/monitor_queries/views/historic.py
+++ b/src/qlever/monitor_queries/views/historic.py
@@ -23,6 +23,10 @@ from qlever.monitor_queries.historic_data import (
     window_metrics,
 )
 from qlever.monitor_queries.live_data import current_ms
+from qlever.monitor_queries.log_reader import (
+    load_sparql_at,
+    open_log_buffer,
+)
 from qlever.monitor_queries.metrics import EMPTY_FIELDS
 from qlever.monitor_queries.models import (
     ControlsState,
@@ -606,10 +610,17 @@ class HistoricScreen(Screen, inherit_bindings=False):
     ) -> None:
         """Show the selected finished query's SPARQL in the pane."""
         row = message.data_table.query_rows[message.cursor_row]
+        # The row holds only the table snippet, so read the full query.
+        with open_log_buffer(self.app.log_file) as buf:
+            sparql = (
+                row.sparql
+                if buf is None
+                else load_sparql_at(buf, row.start_line_offset)[2]
+            )
         self.query_one(SparqlPane).content = SparqlContent(
             qid=row.qid,
             started_at_ms=row.started_at_ms,
             status=row.status,
-            sparql_text=row.sparql,
+            sparql_text=sparql,
             client_ip=row.client_ip,
         )

--- a/src/qlever/monitor_queries/views/historic.py
+++ b/src/qlever/monitor_queries/views/historic.py
@@ -234,15 +234,9 @@ class HistoricScreen(Screen, inherit_bindings=False):
             return state.latest_event_ms
 
     def show_loading_state(self) -> None:
-        """Blank the table and metrics row while a rescan is in flight."""
-        self.query_one(HistoricQueryTable).set_rows([])
-        self.query_one(MetricsRow).rows = [
-            MetricsCounts(
-                label=self.window_size,
-                **EMPTY_FIELDS,
-                not_ready_message="loading…",
-            )
-        ]
+        """Dim the rows so a window change registers before the scan lands."""
+        self.query_one(HistoricQueryTable).add_class("stale")
+        self.query_one(MetricsRow).add_class("stale")
         self.query_one("#table-status", Static).update("Loading window…")
 
     def refresh_view(self, rescan: bool) -> None:
@@ -355,6 +349,8 @@ class HistoricScreen(Screen, inherit_bindings=False):
         metrics: MetricsCounts,
     ) -> None:
         """Push fresh rows, metrics, and status line into the widgets."""
+        self.query_one(HistoricQueryTable).remove_class("stale")
+        self.query_one(MetricsRow).remove_class("stale")
         self.query_one(HistoricQueryTable).set_rows(rows)
         self.query_one(MetricsRow).rows = [metrics]
         self.query_one("#table-status", Static).update(

--- a/src/qlever/monitor_queries/widgets/metrics_row.py
+++ b/src/qlever/monitor_queries/widgets/metrics_row.py
@@ -6,6 +6,7 @@ from textual.reactive import reactive
 from textual.widgets import Static
 
 from qlever.monitor_queries.models import MetricsCounts
+from qlever.monitor_queries.util import format_seconds
 
 METRIC_COLORS = {
     "ok": "$success",
@@ -48,14 +49,10 @@ def format_count(n: int | None) -> str:
 
 
 def format_ms(ms: int | None) -> str:
-    """Render a duration in seconds, ellipsis if not computed.
-
-    Uses 2 decimals under 1 s, 1 decimal otherwise.
-    """
+    """Render a duration to 3 significant figures, ellipsis if unset."""
     if ms is None:
         return "…"
-    seconds = ms / 1000
-    return f"{seconds:.2f}s" if seconds < 1 else f"{seconds:.1f}s"
+    return f"{format_seconds(ms / 1000)}s"
 
 
 def format_value(value: int | None, kind: str) -> str:

--- a/src/qlever/resource_usage/usage_plot.py
+++ b/src/qlever/resource_usage/usage_plot.py
@@ -281,8 +281,12 @@ def write_usage_plot(
 
     max_rss = float(np.nanmax(rss_gb))
     x_max = float(x_values[-1])
-    ax_mem.set_ylim(-max_rss * 0.04, max_rss * 1.4)
-    ax_mem.set_xlim(-x_max * 0.02, x_max * 1.06)
+    # With a single sample both spans are zero, which makes the axis
+    # limits identical; fall back to a unit span so the limits differ.
+    y_span = max_rss if max_rss > 0 else 1.0
+    x_span = x_max if x_max > 0 else 1.0
+    ax_mem.set_ylim(-y_span * 0.04, y_span * 1.4)
+    ax_mem.set_xlim(-x_span * 0.02, x_span * 1.06)
 
     annotate_peak(ax_mem, x_values, rss_gb, "RSS", "#cc0000", (-25, 20))
 

--- a/test/qlever/conftest.py
+++ b/test/qlever/conftest.py
@@ -16,25 +16,6 @@ def write_log(tmp_path):
 
 
 @pytest.fixture
-def open_log(write_log):
-    """Write bytes to a log file and hand back an open (handle, size).
-
-    Closes every handle it produced when the test finishes.
-    """
-    handles = []
-
-    def make(data):
-        path = write_log(data)
-        handle = path.open("rb")
-        handles.append(handle)
-        return handle, path.stat().st_size
-
-    yield make
-    for handle in handles:
-        handle.close()
-
-
-@pytest.fixture
 def mock_command(monkeypatch):
     def _mock(module_name: str, function_name: str, override=None):
         if override:

--- a/test/qlever/test_historic_data.py
+++ b/test/qlever/test_historic_data.py
@@ -611,8 +611,18 @@ def test_filter_by_text_non_ascii_search_text_matches(write_log):
             ("q2", "SELECT b", "x"),
         ],
     )
-    filters = FilterState(sparql_substr="zürich")
+    # A non-ASCII term matches exactly, so the same case is kept.
+    filters = FilterState(sparql_substr="Zürich")
     assert filter_by_text(path, queries, filters) == [queries[0]]
+
+
+def test_filter_by_text_non_ascii_search_text_is_case_sensitive(write_log):
+    path, queries = text_log(
+        write_log, [("q1", "SELECT ?s { ?s rdfs:label 'Zürich' }", "x")]
+    )
+    # Different case on the non-ASCII term does not match.
+    filters = FilterState(sparql_substr="zürich")
+    assert filter_by_text(path, queries, filters) == []
 
 
 def test_filter_by_text_client_ip_on_line_longer_than_head(write_log):

--- a/test/qlever/test_historic_data.py
+++ b/test/qlever/test_historic_data.py
@@ -572,3 +572,54 @@ def test_filter_by_text_combines_client_ip_and_sparql(write_log):
     )
     filters = FilterState(client_ip_substr="192.168", sparql_substr="select")
     assert filter_by_text(path, queries, filters) == [queries[0]]
+
+
+def test_filter_by_text_sparql_with_quotes_matches_escaped_line(write_log):
+    # The file holds \"Berlin\"; the filter uses plain quotes.
+    path, queries = text_log(
+        write_log,
+        [("q1", 'name \\"Berlin\\"', "x"), ("q2", "SELECT b", "x")],
+    )
+    filters = FilterState(sparql_substr='"berlin"')
+    assert filter_by_text(path, queries, filters) == [queries[0]]
+
+
+def test_filter_by_text_sparql_with_newline_matches_escaped_line(write_log):
+    # The file holds line1\nline2; the filter uses a real newline.
+    path, queries = text_log(
+        write_log,
+        [("q1", "line1\\nline2", "x"), ("q2", "SELECT b", "x")],
+    )
+    filters = FilterState(sparql_substr="e1\nl")
+    assert filter_by_text(path, queries, filters) == [queries[0]]
+
+
+def test_filter_by_text_rejects_fake_byte_hit(write_log):
+    # The query is a, backslash, n, t, b, stored as a\\ntb. Those bytes
+    # contain \nt, the escaped form of newline + t, but the decoded
+    # query has no newline, so the query must be dropped.
+    path, queries = text_log(write_log, [("q1", "a\\\\ntb", "x")])
+    filters = FilterState(sparql_substr="\nt")
+    assert filter_by_text(path, queries, filters) == []
+
+
+def test_filter_by_text_non_ascii_search_text_matches(write_log):
+    path, queries = text_log(
+        write_log,
+        [
+            ("q1", "SELECT ?s { ?s rdfs:label 'Zürich' }", "x"),
+            ("q2", "SELECT b", "x"),
+        ],
+    )
+    filters = FilterState(sparql_substr="zürich")
+    assert filter_by_text(path, queries, filters) == [queries[0]]
+
+
+def test_filter_by_text_client_ip_on_line_longer_than_head(write_log):
+    long_query = "SELECT " + "x" * 1000
+    path, queries = text_log(
+        write_log,
+        [("q1", long_query, "192.168.0.7"), ("q2", long_query, "10.0.0.1")],
+    )
+    filters = FilterState(client_ip_substr="192.168")
+    assert filter_by_text(path, queries, filters) == [queries[0]]

--- a/test/qlever/test_log_reader.py
+++ b/test/qlever/test_log_reader.py
@@ -7,6 +7,7 @@ from qlever.monitor_queries.log_reader import (
     load_sparql_at,
     next_whole_line,
     offset_for_ts,
+    open_log_buffer,
     pair_start_end_events,
     parse_line,
     parse_line_fallback,
@@ -112,38 +113,35 @@ SECOND_OFFSET = len(FIRST_LINE)
 THIRD_OFFSET = len(FIRST_LINE) + len(SECOND_LINE)
 
 
-def test_next_whole_line_probe_zero_returns_first_line(open_log):
-    log, size = open_log(FIRST_LINE + SECOND_LINE + THIRD_LINE)
-    assert next_whole_line(log, 0, size) == (0, 1000)
+def test_next_whole_line_probe_zero_returns_first_line():
+    buf = FIRST_LINE + SECOND_LINE + THIRD_LINE
+    assert next_whole_line(buf, 0) == (0, 1000)
 
 
-def test_next_whole_line_mid_line_aligns_to_following_line(open_log):
-    log, size = open_log(FIRST_LINE + SECOND_LINE + THIRD_LINE)
+def test_next_whole_line_mid_line_aligns_to_following_line():
+    buf = FIRST_LINE + SECOND_LINE + THIRD_LINE
     # A probe inside the first line lands on the second.
-    assert next_whole_line(log, 10, size) == (SECOND_OFFSET, 2000)
-    assert next_whole_line(log, SECOND_OFFSET - 1, size) == (
-        SECOND_OFFSET,
-        2000,
-    )
+    assert next_whole_line(buf, 10) == (SECOND_OFFSET, 2000)
+    assert next_whole_line(buf, SECOND_OFFSET - 1) == (SECOND_OFFSET, 2000)
 
 
-def test_next_whole_line_on_a_boundary_advances_to_the_next_line(open_log):
-    log, size = open_log(FIRST_LINE + SECOND_LINE + THIRD_LINE)
+def test_next_whole_line_on_a_boundary_advances_to_the_next_line():
+    buf = FIRST_LINE + SECOND_LINE + THIRD_LINE
     # probe > 0 always discards one line, so a probe on the second
     # line's start returns the third.
-    assert next_whole_line(log, SECOND_OFFSET, size) == (THIRD_OFFSET, 3000)
+    assert next_whole_line(buf, SECOND_OFFSET) == (THIRD_OFFSET, 3000)
 
 
-def test_next_whole_line_past_eof_returns_none(open_log):
-    log, size = open_log(FIRST_LINE + SECOND_LINE)
-    assert next_whole_line(log, size, size) is None
+def test_next_whole_line_past_eof_returns_none():
+    buf = FIRST_LINE + SECOND_LINE
+    assert next_whole_line(buf, len(buf)) is None
 
 
-def test_next_whole_line_trailing_partial_line_returns_none(open_log):
+def test_next_whole_line_trailing_partial_line_returns_none():
     partial = b'{"ts-ms":4000,"event":"end","qid":"q3"'
-    log, size = open_log(FIRST_LINE + partial)
+    buf = FIRST_LINE + partial
     # The only line after the probe has no newline, so it is incomplete.
-    assert next_whole_line(log, 5, size) is None
+    assert next_whole_line(buf, 5) is None
 
 
 def build_log(timestamps):
@@ -159,120 +157,123 @@ def build_log(timestamps):
     return bytes(data), offsets
 
 
-def first_ts_at_or_after(log, offset, target):
+def first_ts_at_or_after(buf, offset, target):
     """ts of the first line at/after offset, or None if every line older."""
-    log.seek(offset)
-    for line in log:
-        ts = peek_ts_ms(line)
-        if ts >= target:
+    while offset < len(buf):
+        end = buf.find(b"\n", offset)
+        if end == -1:
+            return None
+        ts = peek_ts_ms(buf[offset:end])
+        if ts is not None and ts >= target:
             return ts
+        offset = end + 1
     return None
 
 
-def test_offset_for_ts_empty_file_returns_zero(open_log):
-    log, size = open_log(b"")
-    assert offset_for_ts(log, 100, size) == 0
-
-
-def test_offset_for_ts_target_before_first_line_returns_zero(open_log):
+def test_offset_for_ts_target_before_first_line_returns_zero():
     data, _ = build_log([1000, 1010, 1020])
-    log, size = open_log(data)
-    assert offset_for_ts(log, 500, size) == 0
+    assert offset_for_ts(data, 500) == 0
 
 
-def test_offset_for_ts_target_equal_to_first_line_returns_zero(open_log):
+def test_offset_for_ts_target_equal_to_first_line_returns_zero():
     data, _ = build_log([1000, 1010, 1020])
-    log, size = open_log(data)
     # first_ts >= target means every line qualifies; start at 0.
-    assert offset_for_ts(log, 1000, size) == 0
+    assert offset_for_ts(data, 1000) == 0
 
 
 @pytest.mark.parametrize("target", [1015, 1020, 1099, 1500, 1900])
-def test_offset_for_ts_lands_at_or_before_the_boundary(
-    open_log, monkeypatch, target
-):
+def test_offset_for_ts_lands_at_or_before_the_boundary(monkeypatch, target):
     # Tiny gallop step so the backward gallop actually iterates here.
     monkeypatch.setattr(log_reader, "GALLOP_START", 16)
     timestamps = list(range(1000, 2000, 10))
     data, offsets = build_log(timestamps)
-    log, size = open_log(data)
 
-    result = offset_for_ts(log, target, size)
+    result = offset_for_ts(data, target)
 
     # Never overshoots: the returned line is not newer than target, so
     # no line with ts >= target was skipped.
     boundary = next(o for o, ts in zip(offsets, timestamps) if ts >= target)
     assert result <= boundary
-    assert first_ts_at_or_after(log, result, target) == next(
+    assert first_ts_at_or_after(data, result, target) == next(
         ts for ts in timestamps if ts >= target
     )
 
 
-def test_offset_for_ts_target_past_last_line_yields_empty_scan(
-    open_log, monkeypatch
-):
+def test_offset_for_ts_target_past_last_line_yields_empty_scan(monkeypatch):
     monkeypatch.setattr(log_reader, "GALLOP_START", 16)
     data, _ = build_log(list(range(1000, 2000, 10)))
-    log, size = open_log(data)
 
-    result = offset_for_ts(log, 9999, size)
+    result = offset_for_ts(data, 9999)
 
-    # Near EOF, not necessarily file_size, but a forward scan from it
+    # Near EOF, not necessarily len(buf), but a forward scan from it
     # finds nothing at or after the target: the same empty result.
-    assert first_ts_at_or_after(log, result, 9999) is None
+    assert first_ts_at_or_after(data, result, 9999) is None
 
 
-def test_scan_range_yields_each_whole_line_with_its_offset(open_log):
+def test_scan_range_yields_each_whole_line_with_its_offset():
     data, offsets = build_log([1000, 1010, 1020])
-    log, size = open_log(data)
-    assert list(scan_range(log, 0, size)) == [
+    assert list(scan_range(data, 0, len(data))) == [
         ((1000, "end", "q0", "ok"), offsets[0]),
         ((1010, "end", "q1", "ok"), offsets[1]),
         ((1020, "end", "q2", "ok"), offsets[2]),
     ]
 
 
-def test_scan_range_includes_the_line_straddling_hi_bound(open_log):
+def test_scan_range_includes_the_line_straddling_hi_bound():
     data, offsets = build_log([1000, 1010, 1020])
-    log, size = open_log(data)
     # hi_bound falls inside the second line. The second line starts
     # before it so it is still emitted; the third starts past it.
-    result = list(scan_range(log, 0, offsets[1] + 3))
+    result = list(scan_range(data, 0, offsets[1] + 3))
     assert [ts for (ts, _, _, _), _ in result] == [1000, 1010]
 
 
-def test_scan_range_stops_before_a_trailing_partial_line(open_log):
+def test_scan_range_stops_before_a_trailing_partial_line():
     data, _ = build_log([1000])
-    log, size = open_log(data + b'{"ts-ms":2000,"event":"end","qid":"q9"')
-    assert list(scan_range(log, 0, size)) == [
+    buf = data + b'{"ts-ms":2000,"event":"end","qid":"q9"'
+    assert list(scan_range(buf, 0, len(buf))) == [
         ((1000, "end", "q0", "ok"), 0),
     ]
 
 
-def test_scan_range_skips_a_malformed_line_and_continues(open_log):
+def test_scan_range_skips_a_malformed_line_and_continues():
     good = b'{"ts-ms":1000,"event":"end","qid":"q0","status":"ok"}\n'
     junk = b"not json at all\n"
     tail = b'{"ts-ms":1020,"event":"end","qid":"q2","status":"ok"}\n'
-    log, size = open_log(good + junk + tail)
-    assert list(scan_range(log, 0, size)) == [
+    buf = good + junk + tail
+    assert list(scan_range(buf, 0, len(buf))) == [
         ((1000, "end", "q0", "ok"), 0),
         ((1020, "end", "q2", "ok"), len(good) + len(junk)),
     ]
 
 
-def test_scan_range_recovers_a_line_via_the_json_fallback(open_log):
+def test_scan_range_recovers_a_line_via_the_json_fallback():
     # Leading space defeats the fast byte path but is valid JSON.
-    line = b'{ "ts-ms":2000,"event":"end","qid":"q1","status":"ok"}\n'
-    log, size = open_log(line)
-    assert list(scan_range(log, 0, size)) == [
+    buf = b'{ "ts-ms":2000,"event":"end","qid":"q1","status":"ok"}\n'
+    assert list(scan_range(buf, 0, len(buf))) == [
         ((2000, "end", "q1", "ok"), 0),
     ]
 
 
-def test_scan_range_from_eof_yields_nothing(open_log):
+def test_scan_range_parses_a_line_longer_than_head_bytes():
+    # The query blob pushes the line well past HEAD_BYTES, but the
+    # header fields sit in the head slice, so the line still parses
+    # without reading the blob.
+    big_query = b"x" * (log_reader.HEAD_BYTES * 4)
+    start = (
+        b'{"ts-ms":1000,"event":"start","qid":"q0",'
+        b'"query":"' + big_query + b'"}\n'
+    )
+    end = b'{"ts-ms":1010,"event":"end","qid":"q0","status":"ok"}\n'
+    buf = start + end
+    assert list(scan_range(buf, 0, len(buf))) == [
+        ((1000, "start", "q0", None), 0),
+        ((1010, "end", "q0", "ok"), len(start)),
+    ]
+
+
+def test_scan_range_from_eof_yields_nothing():
     data, _ = build_log([1000, 1010])
-    log, size = open_log(data)
-    assert list(scan_range(log, size, size)) == []
+    assert list(scan_range(data, len(data), len(data))) == []
 
 
 def test_pair_start_end_events_empty_input_yields_empty_outputs():
@@ -419,52 +420,48 @@ def test_extract_qid_ip_query_malformed_json_returns_empty():
     assert extract_qid_ip_query(b"this is not json\n") == ("", "", "")
 
 
-def test_load_sparql_at_returns_qid_ip_and_query(open_log):
-    line = (
+def test_load_sparql_at_returns_qid_ip_and_query():
+    buf = (
         b'{"ts-ms":1,"event":"start","qid":"q1","client-ip":"1.2.3.4",'
         b'"query":"SELECT * WHERE { ?s ?p ?o }"}\n'
     )
-    log, _ = open_log(line)
-    assert load_sparql_at(log, 0) == (
+    assert load_sparql_at(buf, 0) == (
         "q1",
         "1.2.3.4",
         "SELECT * WHERE { ?s ?p ?o }",
     )
 
 
-def test_load_sparql_at_handles_escaped_quotes_and_backslashes(open_log):
+def test_load_sparql_at_handles_escaped_quotes_and_backslashes():
     # The JSON value encodes a literal " and a literal \ in the query.
-    line = (
+    buf = (
         b'{"ts-ms":1,"event":"start","qid":"q1","client-ip":"1.2.3.4",'
         b'"query":"SELECT ?x WHERE { ?x ?p \\"a\\\\b\\" }"}\n'
     )
-    log, _ = open_log(line)
-    assert load_sparql_at(log, 0) == (
+    assert load_sparql_at(buf, 0) == (
         "q1",
         "1.2.3.4",
         'SELECT ?x WHERE { ?x ?p "a\\b" }',
     )
 
 
-def test_load_sparql_at_handles_unicode(open_log):
-    line = (
+def test_load_sparql_at_handles_unicode():
+    buf = (
         b'{"ts-ms":1,"event":"start","qid":"q1","client-ip":"1.2.3.4",'
         b'"query":"SELECT ?s WHERE { ?s ?p \xe2\x98\x83 }"}\n'
     )
-    log, _ = open_log(line)
-    assert load_sparql_at(log, 0) == (
+    assert load_sparql_at(buf, 0) == (
         "q1",
         "1.2.3.4",
         "SELECT ?s WHERE { ?s ?p ☃ }",
     )
 
 
-def test_load_sparql_at_malformed_json_returns_empty(open_log):
-    log, _ = open_log(b"this is not json\n")
-    assert load_sparql_at(log, 0) == ("", "", "")
+def test_load_sparql_at_malformed_json_returns_empty():
+    assert load_sparql_at(b"this is not json\n", 0) == ("", "", "")
 
 
-def test_load_sparql_at_reads_the_line_at_the_given_offset(open_log):
+def test_load_sparql_at_reads_the_line_at_the_given_offset():
     first = (
         b'{"ts-ms":1,"event":"start","qid":"q1","client-ip":"1.2.3.4",'
         b'"query":"FIRST"}\n'
@@ -473,57 +470,57 @@ def test_load_sparql_at_reads_the_line_at_the_given_offset(open_log):
         b'{"ts-ms":2,"event":"start","qid":"q2","client-ip":"5.6.7.8",'
         b'"query":"SECOND"}\n'
     )
-    log, _ = open_log(first + second)
-    assert load_sparql_at(log, len(first)) == ("q2", "5.6.7.8", "SECOND")
+    assert load_sparql_at(first + second, len(first)) == (
+        "q2",
+        "5.6.7.8",
+        "SECOND",
+    )
 
 
-def test_read_last_timestamp_empty_file_returns_none(open_log):
-    log, size = open_log(b"")
-    assert read_last_timestamp(log, size) is None
+def test_read_last_timestamp_returns_last_complete_line_ts():
+    assert read_last_timestamp(FIRST_LINE + SECOND_LINE) == 2000
 
 
-def test_read_last_timestamp_returns_last_complete_line_ts(open_log):
-    log, size = open_log(FIRST_LINE + SECOND_LINE)
-    assert read_last_timestamp(log, size) == 2000
-
-
-def test_read_last_timestamp_skips_trailing_partial_line(open_log):
+def test_read_last_timestamp_skips_trailing_partial_line():
     partial = b'{"ts-ms":3000,"event":"end","qid":"q2","status'
-    log, size = open_log(FIRST_LINE + SECOND_LINE + partial)
-    assert read_last_timestamp(log, size) == 2000
+    assert read_last_timestamp(FIRST_LINE + SECOND_LINE + partial) == 2000
 
 
-def test_read_last_timestamp_grows_buffer_for_long_lines(open_log):
+def test_read_last_timestamp_handles_a_long_last_line():
+    # rfind walks back over the whole line regardless of its size.
     long_query = b"x" * (40 * 1024)
     line = (
         b'{"ts-ms":1000,"event":"start","qid":"q1",'
         b'"query":"' + long_query + b'"}\n'
     )
-    log, size = open_log(line)
-    assert read_last_timestamp(log, size) == 1000
+    assert read_last_timestamp(line) == 1000
 
 
-def test_read_first_timestamp_empty_file_returns_none(open_log):
-    log, size = open_log(b"")
-    assert read_first_timestamp(log, size) is None
+def test_read_first_timestamp_returns_first_complete_line_ts():
+    assert read_first_timestamp(FIRST_LINE + SECOND_LINE) == 1000
 
 
-def test_read_first_timestamp_returns_first_complete_line_ts(open_log):
-    log, size = open_log(FIRST_LINE + SECOND_LINE)
-    assert read_first_timestamp(log, size) == 1000
+def test_read_first_timestamp_single_line():
+    assert read_first_timestamp(FIRST_LINE) == 1000
 
 
-def test_read_first_timestamp_single_line(open_log):
-    log, size = open_log(FIRST_LINE)
-    assert read_first_timestamp(log, size) == 1000
+def test_read_first_timestamp_malformed_first_line_returns_none():
+    # We read only the first line; a malformed one yields None rather
+    # than scanning forward (the real log's first line is well-formed).
+    assert read_first_timestamp(b"not a log line\n" + SECOND_LINE) is None
 
 
-def test_read_first_timestamp_skips_malformed_first_line(open_log):
-    log, size = open_log(b"not a log line\n" + SECOND_LINE)
-    assert read_first_timestamp(log, size) == 2000
-
-
-def test_read_first_timestamp_unterminated_only_line_returns_none(open_log):
+def test_read_first_timestamp_unterminated_only_line_returns_none():
     partial = b'{"ts-ms":1000,"event":"start","qid":"q1"'
-    log, size = open_log(partial)
-    assert read_first_timestamp(log, size) is None
+    assert read_first_timestamp(partial) is None
+
+
+def test_open_log_buffer_empty_file_yields_none(write_log):
+    with open_log_buffer(write_log(b"")) as buf:
+        assert buf is None
+
+
+def test_open_log_buffer_maps_a_nonempty_file(write_log):
+    with open_log_buffer(write_log(FIRST_LINE + SECOND_LINE)) as buf:
+        assert read_first_timestamp(buf) == 1000
+        assert read_last_timestamp(buf) == 2000

--- a/test/qlever/test_log_reader.py
+++ b/test/qlever/test_log_reader.py
@@ -5,6 +5,7 @@ from qlever.monitor_queries.log_reader import (
     SNIPPET_BYTES,
     CompletedQuery,
     extract_qid_ip_query,
+    line_query_contains,
     load_sparql_at,
     load_sparql_snippet_at,
     next_whole_line,
@@ -420,6 +421,59 @@ def test_extract_qid_ip_query_missing_client_ip_falls_back_to_empty():
 
 def test_extract_qid_ip_query_malformed_json_returns_empty():
     assert extract_qid_ip_query(b"this is not json\n") == ("", "", "")
+
+
+def query_contains(query, raw_search):
+    """Build a start line around `query` and run line_query_contains."""
+    line = (
+        b'{"ts-ms":1,"event":"start","qid":"q77","client-ip":"1.2.3.4",'
+        b'"query":"' + query + b'"}\n'
+    )
+    return line_query_contains(line, 0, len(line) - 1, raw_search)
+
+
+def test_line_query_contains_finds_plain_text():
+    assert query_contains(b"SELECT * WHERE { ?s ?p ?o }", b"where")
+
+
+def test_line_query_contains_is_case_insensitive():
+    assert query_contains(b"SELECT * WHERE { ?s ?p ?o }", b"select")
+
+
+def test_line_query_contains_missing_text_is_false():
+    assert not query_contains(b"SELECT * WHERE { ?s ?p ?o }", b"construct")
+
+
+def test_line_query_contains_matches_escaped_quote():
+    # The file holds \"berlin\"; the search is escaped the same way.
+    assert query_contains(b'name \\"Berlin\\"', b'\\"berlin\\"')
+
+
+def test_line_query_contains_rejects_hit_inside_escape():
+    # The query is a, backslash, n, t, b: its bytes contain \nt, the
+    # escaped form of newline + t, but the query has no newline.
+    assert not query_contains(b"a\\\\ntb", b"\\nt")
+
+
+def test_line_query_contains_skips_fake_hit_then_finds_real_one():
+    # The query is a, backslash, newline, t, b: the first \nt hit
+    # starts inside the \\ escape, the second is the real newline.
+    assert query_contains(b"a\\\\\\ntb", b"\\nt")
+
+
+def test_line_query_contains_ignores_other_fields():
+    # q77 appears in the qid field, not in the query.
+    assert not query_contains(b"SELECT 1", b"q77")
+
+
+def test_line_query_contains_ignores_line_closing_bytes():
+    # The trailing "} closes the line itself, not query text.
+    assert not query_contains(b"SELECT 1", b'1"}')
+
+
+def test_line_query_contains_line_without_query_key_is_false():
+    line = b'{"ts-ms":1,"event":"end","qid":"q1","status":"ok"}\n'
+    assert not line_query_contains(line, 0, len(line) - 1, b"ok")
 
 
 def test_load_sparql_at_returns_qid_ip_and_query():

--- a/test/qlever/test_log_reader.py
+++ b/test/qlever/test_log_reader.py
@@ -2,9 +2,11 @@ import pytest
 
 from qlever.monitor_queries import log_reader
 from qlever.monitor_queries.log_reader import (
+    SNIPPET_BYTES,
     CompletedQuery,
     extract_qid_ip_query,
     load_sparql_at,
+    load_sparql_snippet_at,
     next_whole_line,
     offset_for_ts,
     open_log_buffer,
@@ -474,6 +476,71 @@ def test_load_sparql_at_reads_the_line_at_the_given_offset():
         "q2",
         "5.6.7.8",
         "SECOND",
+    )
+
+
+def snippet_line(query: bytes) -> bytes:
+    """A start line whose query value is the raw (escaped) `query` bytes."""
+    return (
+        b'{"ts-ms":1,"event":"start","qid":"q1","client-ip":"1.2.3.4",'
+        b'"query":"' + query + b'"}\n'
+    )
+
+
+def test_load_sparql_snippet_at_short_query_decodes_in_full():
+    assert load_sparql_snippet_at(
+        snippet_line(b"SELECT * { ?s ?p ?o }"), 0
+    ) == (
+        "q1",
+        "1.2.3.4",
+        "SELECT * { ?s ?p ?o }",
+    )
+
+
+def test_load_sparql_snippet_at_handles_escapes():
+    # Escaped quote, backslash, and newline in a short query.
+    buf = snippet_line(b'a\\"b\\\\c\\nd')
+    assert load_sparql_snippet_at(buf, 0) == ("q1", "1.2.3.4", 'a"b\\c\nd')
+
+
+def test_load_sparql_snippet_at_reads_at_the_given_offset():
+    first = snippet_line(b"FIRST")
+    second = (
+        b'{"ts-ms":2,"event":"start","qid":"q2","client-ip":"5.6.7.8",'
+        b'"query":"SECOND"}\n'
+    )
+    assert load_sparql_snippet_at(first + second, len(first)) == (
+        "q2",
+        "5.6.7.8",
+        "SECOND",
+    )
+
+
+def test_load_sparql_snippet_at_caps_a_long_query():
+    # A query far past the cap is read only up to SNIPPET_BYTES chars.
+    qid, client_ip, sparql = load_sparql_snippet_at(
+        snippet_line(b"x" * (SNIPPET_BYTES * 4)), 0
+    )
+    assert (qid, client_ip) == ("q1", "1.2.3.4")
+    assert sparql == "x" * SNIPPET_BYTES
+
+
+def test_load_sparql_snippet_at_trims_an_escape_split_by_the_cap():
+    # The cap lands on the backslash of a `\n` escape. The split escape
+    # is dropped so the snippet still decodes, one char short of the cap.
+    buf = snippet_line(b"a" * (SNIPPET_BYTES - 1) + b"\\n" + b"b" * 50)
+    assert load_sparql_snippet_at(buf, 0) == (
+        "q1",
+        "1.2.3.4",
+        "a" * (SNIPPET_BYTES - 1),
+    )
+
+
+def test_load_sparql_snippet_at_empty_query():
+    assert load_sparql_snippet_at(snippet_line(b""), 0) == (
+        "q1",
+        "1.2.3.4",
+        "",
     )
 
 

--- a/test/qlever/test_log_reader.py
+++ b/test/qlever/test_log_reader.py
@@ -423,13 +423,13 @@ def test_extract_qid_ip_query_malformed_json_returns_empty():
     assert extract_qid_ip_query(b"this is not json\n") == ("", "", "")
 
 
-def query_contains(query, raw_search):
+def query_contains(query, raw_search, ignore_case=True):
     """Build a start line around `query` and run line_query_contains."""
     line = (
         b'{"ts-ms":1,"event":"start","qid":"q77","client-ip":"1.2.3.4",'
         b'"query":"' + query + b'"}\n'
     )
-    return line_query_contains(line, 0, len(line) - 1, raw_search)
+    return line_query_contains(line, 0, len(line) - 1, raw_search, ignore_case)
 
 
 def test_line_query_contains_finds_plain_text():
@@ -461,6 +461,16 @@ def test_line_query_contains_skips_fake_hit_then_finds_real_one():
     assert query_contains(b"a\\\\\\ntb", b"\\nt")
 
 
+def test_line_query_contains_exact_matches_same_case():
+    query = "label 'Zürich'".encode()
+    assert query_contains(query, "Zürich".encode(), ignore_case=False)
+
+
+def test_line_query_contains_exact_rejects_other_case():
+    query = "label 'Zürich'".encode()
+    assert not query_contains(query, "zürich".encode(), ignore_case=False)
+
+
 def test_line_query_contains_ignores_other_fields():
     # q77 appears in the qid field, not in the query.
     assert not query_contains(b"SELECT 1", b"q77")
@@ -473,7 +483,7 @@ def test_line_query_contains_ignores_line_closing_bytes():
 
 def test_line_query_contains_line_without_query_key_is_false():
     line = b'{"ts-ms":1,"event":"end","qid":"q1","status":"ok"}\n'
-    assert not line_query_contains(line, 0, len(line) - 1, b"ok")
+    assert not line_query_contains(line, 0, len(line) - 1, b"ok", True)
 
 
 def test_load_sparql_at_returns_qid_ip_and_query():


### PR DESCRIPTION
So far, scanning the metrics log copied every line in full, including the large SPARQL query text that makes up most of a line, even though only the small header (timestamp, event, query id) was needed to walk the log.  Now the log is mapped into memory, line boundaries are found with a fast scan that copies nothing, and only the first 256 bytes of each line are read for the necessary fields. The query text is no longer touched while scanning.

The tables on live and historic screens also read only the first 256 bytes of a query, since they show a truncated snippet anyway, and decode the full query only when its row is selected. Filtering by client IP or SPARQL text matches against the raw log bytes instead of decoding each candidate line. Together this keeps scanning, filtering, and switching windows fast even on logs with millions of queries.

While at it, fix a `matplotlib` warning in the resource usage plot when there is only a single sample.