### PR TITLE
Fix freeze and flicker in `qlever monitor-queries`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
  "Topic :: Database :: Front-Ends"
 ]
 
-dependencies = [ "psutil", "termcolor", "argcomplete", "pyyaml", "rdflib", "requests-sse", "tqdm>=4.60.0", "textual>=8.0", "textual-plotext", "rich" ]
+dependencies = [ "psutil", "termcolor", "argcomplete", "pyyaml", "rdflib", "requests-sse", "tqdm>=4.60.0", "textual>=8.0,<9", "textual-plotext", "rich" ]
 
 [project.optional-dependencies]
 plot = [ "matplotlib", "numpy" ]

--- a/src/qlever/monitor_queries/views/filter_modal.py
+++ b/src/qlever/monitor_queries/views/filter_modal.py
@@ -6,10 +6,11 @@ from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import ModalScreen
 from textual.validation import Integer
-from textual.widgets import Footer, Input, Label, SelectionList
+from textual.widgets import Input, Label, SelectionList
 from textual.widgets.selection_list import Selection
 
 from qlever.monitor_queries.models import FilterState
+from qlever.monitor_queries.widgets.footer import Footer
 
 # Statuses offered in the filter, in display order: the terminal
 # statuses a completed query can carry, plus orphaned crash survivors.

--- a/src/qlever/monitor_queries/views/historic.py
+++ b/src/qlever/monitor_queries/views/historic.py
@@ -8,7 +8,7 @@ from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.screen import Screen
-from textual.widgets import Footer, Static
+from textual.widgets import Static
 from textual.worker import get_current_worker
 
 from qlever.monitor_queries.historic_data import (
@@ -51,6 +51,7 @@ from qlever.monitor_queries.views.resource_plot_modal import (
 )
 from qlever.monitor_queries.widgets.controls_row import HistoricControlsRow
 from qlever.monitor_queries.widgets.detail_switcher import DetailSwitcher
+from qlever.monitor_queries.widgets.footer import Footer
 from qlever.monitor_queries.widgets.header_row import HeaderRow
 from qlever.monitor_queries.widgets.metrics_row import MetricsRow
 from qlever.monitor_queries.widgets.mode_picker import MODES, ModePicker

--- a/src/qlever/monitor_queries/views/live.py
+++ b/src/qlever/monitor_queries/views/live.py
@@ -7,7 +7,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.reactive import reactive
 from textual.screen import Screen
-from textual.widgets import Footer, Static
+from textual.widgets import Static
 from textual.worker import get_current_worker
 
 from qlever.monitor_queries.live_data import (
@@ -40,6 +40,7 @@ from qlever.monitor_queries.widgets.detail_switcher import (
     PLOT_ID,
     DetailSwitcher,
 )
+from qlever.monitor_queries.widgets.footer import Footer
 from qlever.monitor_queries.widgets.header_row import HeaderRow
 from qlever.monitor_queries.widgets.metrics_row import MetricsRow
 from qlever.monitor_queries.widgets.nav_pill import NavPill

--- a/src/qlever/monitor_queries/views/resource_plot_modal.py
+++ b/src/qlever/monitor_queries/views/resource_plot_modal.py
@@ -14,10 +14,10 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Footer
 from textual.worker import get_current_worker
 
 from qlever.monitor_queries.models import ResourcePlot
+from qlever.monitor_queries.widgets.footer import Footer
 from qlever.monitor_queries.widgets.resource_plot_pane import ResourcePlotPane
 
 

--- a/src/qlever/monitor_queries/widgets/footer.py
+++ b/src/qlever/monitor_queries/widgets/footer.py
@@ -58,7 +58,14 @@ class Footer(TextualFooter):
         yield from super().compose()
 
     def bindings_changed(self, screen: Screen) -> None:
-        """Rebuild only when the keys have changed."""
-        if shown_keys(screen) == self.drawn_keys:
+        """Rebuild only when the keys the footer shows have changed."""
+        # Only this footer's own screen drives its rows, and only while it
+        # is attached, which is exactly where the parent redraws. For any
+        # other screen defer to the parent, which turns it into a no-op.
+        if (
+            self.is_attached
+            and screen is self.screen
+            and shown_keys(screen) == self.drawn_keys
+        ):
             return
         super().bindings_changed(screen)

--- a/src/qlever/monitor_queries/widgets/footer.py
+++ b/src/qlever/monitor_queries/widgets/footer.py
@@ -2,23 +2,39 @@
 
 Textual rebuilds every key whenever bindings are refreshed, including the
 refreshes fired when the terminal window gains or loses focus. Those
-rebuilds retain memory and change nothing on screen.
+rebuilds change nothing on screen, and the replaced key widgets are never
+freed (verified with Textual 8.2.8: 200 redundant refreshes leave 400 dead
+`FooterKey` widgets behind, surviving a forced garbage collection), which
+over a long session degrades the app into a flickering, frozen state.
 """
 
 from __future__ import annotations
 
+from textual.app import ComposeResult
 from textual.screen import Screen
 from textual.widgets import Footer as TextualFooter
 
+# Key, displayed key, label, enabled state and tooltip of one shown
+# binding: everything a footer row is drawn from (a click simulates the
+# key, so the action does not matter here).
+ShownKey = tuple[str, str, str, bool, str]
 
-def shown_keys(screen: Screen) -> tuple[tuple[str, str, bool], ...]:
-    """Key, label and enabled state of every binding the footer shows.
 
-    An unchanged result means a rebuild would draw the same row.
+def shown_keys(screen: Screen) -> tuple[ShownKey, ...]:
+    """What the footer of the given screen shows, one tuple per binding.
+
+    An unchanged result means a rebuild would draw the same rows.
     """
+    get_key_display = screen.app.get_key_display
     return tuple(
-        (binding.key, binding.description, enabled)
-        for _, binding, enabled, _ in screen.active_bindings.values()
+        (
+            binding.key,
+            get_key_display(binding),
+            binding.description,
+            enabled,
+            tooltip,
+        )
+        for _, binding, enabled, tooltip in screen.active_bindings.values()
         if binding.show
     )
 
@@ -27,12 +43,22 @@ class Footer(TextualFooter):
     """Key hint bar that skips rebuilds that would change nothing."""
 
     # What the keys on screen were built from. None before the first
-    # build, so that one always reaches the parent and draws the row.
-    drawn_keys = None
+    # build, so that one always reaches the parent and draws the rows.
+    drawn_keys: tuple[ShownKey, ...] | None = None
+
+    def compose(self) -> ComposeResult:
+        # Record what is drawn AT DRAW TIME, and only when the parent
+        # actually draws the keys. Recording in `bindings_changed` instead
+        # would go stale when the parent skips the rebuild (it does so
+        # while the terminal is unfocused): a change arriving then must
+        # keep differing from `drawn_keys`, so that it is drawn on
+        # refocus.
+        if self._bindings_ready:
+            self.drawn_keys = shown_keys(self.screen)
+        yield from super().compose()
 
     def bindings_changed(self, screen: Screen) -> None:
         """Rebuild only when the keys have changed."""
-        keys = shown_keys(screen)
-        if keys != self.drawn_keys:
-            self.drawn_keys = keys
-            super().bindings_changed(screen)
+        if shown_keys(screen) == self.drawn_keys:
+            return
+        super().bindings_changed(screen)

--- a/src/qlever/monitor_queries/widgets/footer.py
+++ b/src/qlever/monitor_queries/widgets/footer.py
@@ -1,0 +1,38 @@
+"""Footer that only rebuilds when the keys it shows change.
+
+Textual rebuilds every key whenever bindings are refreshed, including the
+refreshes fired when the terminal window gains or loses focus. Those
+rebuilds retain memory and change nothing on screen.
+"""
+
+from __future__ import annotations
+
+from textual.screen import Screen
+from textual.widgets import Footer as TextualFooter
+
+
+def shown_keys(screen: Screen) -> tuple[tuple[str, str, bool], ...]:
+    """Key, label and enabled state of every binding the footer shows.
+
+    An unchanged result means a rebuild would draw the same row.
+    """
+    return tuple(
+        (binding.key, binding.description, enabled)
+        for _, binding, enabled, _ in screen.active_bindings.values()
+        if binding.show
+    )
+
+
+class Footer(TextualFooter):
+    """Key hint bar that skips rebuilds that would change nothing."""
+
+    # What the keys on screen were built from. None before the first
+    # build, so that one always reaches the parent and draws the row.
+    drawn_keys = None
+
+    def bindings_changed(self, screen: Screen) -> None:
+        """Rebuild only when the keys have changed."""
+        keys = shown_keys(screen)
+        if keys != self.drawn_keys:
+            self.drawn_keys = keys
+            super().bindings_changed(screen)

--- a/test/qlever/test_footer.py
+++ b/test/qlever/test_footer.py
@@ -1,0 +1,113 @@
+"""Tests for the rebuild-skipping Footer of monitor-queries.
+
+The stock Textual Footer rebuilds all of its key widgets on every bindings
+refresh (fired, among others, on every terminal focus change) and leaks
+the replaced widgets. The subclass skips rebuilds that would draw the same
+rows. These tests pin down the three behaviors that matter: redundant
+refreshes cause no rebuild, a real change still rebuilds, and a change
+arriving while the terminal is unfocused is drawn on refocus.
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual import events  # noqa: E402
+from textual.app import App  # noqa: E402
+from textual.binding import Binding  # noqa: E402
+
+from qlever.monitor_queries.widgets.footer import Footer  # noqa: E402
+
+
+class CountingFooter(Footer):
+    """Footer that counts its rebuilds."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.rebuilds = 0
+
+    async def recompose(self):
+        self.rebuilds += 1
+        await super().recompose()
+
+
+class FooterApp(App):
+    """Two bindings, one of which can be disabled dynamically."""
+
+    BINDINGS = [
+        Binding("a", "alpha", "Alpha"),
+        Binding("b", "beta", "Beta"),
+    ]
+
+    def __init__(self):
+        super().__init__()
+        self.allow_beta = True
+
+    def compose(self):
+        yield CountingFooter(show_command_palette=False)
+
+    def check_action(self, action, parameters):
+        if action == "beta" and not self.allow_beta:
+            return None
+        return True
+
+
+def disabled_keys(app):
+    return [key.key for key in app.query("FooterKey") if key._disabled]
+
+
+def test_redundant_refreshes_do_not_rebuild():
+    async def run():
+        app = FooterApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            footer = app.query_one(CountingFooter)
+            before = footer.rebuilds
+            for _ in range(20):
+                app.screen.refresh_bindings()
+                await pilot.pause()
+            assert footer.rebuilds == before
+
+    asyncio.run(run())
+
+
+def test_real_change_rebuilds():
+    async def run():
+        app = FooterApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            footer = app.query_one(CountingFooter)
+            before = footer.rebuilds
+            app.allow_beta = False
+            app.screen.refresh_bindings()
+            await pilot.pause()
+            assert footer.rebuilds > before
+            assert disabled_keys(app) == ["b"]
+
+    asyncio.run(run())
+
+
+def test_change_while_unfocused_is_drawn_on_refocus():
+    async def run():
+        app = FooterApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Disable the binding, then re-enable it while the terminal
+            # is unfocused (the parent skips rebuilds then), then refocus.
+            app.allow_beta = False
+            app.screen.refresh_bindings()
+            await pilot.pause()
+            assert disabled_keys(app) == ["b"]
+            app.post_message(events.AppBlur())
+            await pilot.pause()
+            app.allow_beta = True
+            app.screen.refresh_bindings()
+            await pilot.pause()
+            app.post_message(events.AppFocus())
+            await pilot.pause()
+            await pilot.pause()
+            assert disabled_keys(app) == []
+
+    asyncio.run(run())


### PR DESCRIPTION
After running for a while, `qlever monitor-queries` could end up in a state where the whole screen flickered between two renderings and no longer reacted to any input, so that the process had to be killed.

The cause is Textual's built-in `Footer`. It rebuilds all of its key hints whenever the screen refreshes its bindings, which happens on every focus change within the app and every time the terminal window gains or loses focus, even when nothing visible changes. Each rebuild creates new key widgets, and the replaced ones are never freed. This was verified empirically with the stock `Footer` of Textual 8.2.8: after 200 redundant binding refreshes, 400 dead `FooterKey` widgets remain alive even after a forced garbage collection. Over a long session these accumulate until the UI can no longer keep up, which shows as the flicker and freeze described above.

This change adds a small `Footer` subclass that remembers what its rows are drawn from (key, displayed key, label, enabled state, and tooltip) and skips a rebuild when that is unchanged. Rebuilds that do change something (for example, a binding becoming enabled or disabled) still go through, including when the change arrives while the terminal is unfocused. All four screens with a footer now use this subclass, and three regression tests cover the behaviors: redundant refreshes cause no rebuild, a real change still rebuilds, and a change made while unfocused is drawn on refocus.

NOTE: The underlying widget leak is in Textual itself and should be reported upstream; this PR works around it by avoiding the needless rebuilds in the first place, which is worthwhile anyway.