### PR TITLE
Append to the server log on restart instead of overwriting it

### DIFF
--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -70,7 +70,7 @@ def construct_command(args) -> str:
             f" {shlex.quote(view_name)}"
             for view_name in preload_materialized_views
         )
-    start_cmd += f" > {args.name}.server-log.txt 2>&1"
+    start_cmd += f" >> {args.name}.server-log.txt 2>&1"
     return start_cmd
 
 
@@ -300,10 +300,12 @@ class StartCommand(QleverCommand):
         #                   f" (use `lsof -i :{port}` to find out which one)")
         #         return False
 
-        # Remove old log file so that the wait loop below correctly
-        # waits for the server to create a fresh one.
+        # The server log is opened in append mode, so that the log of a
+        # previous run (in particular, the last messages before a crash) is
+        # not lost. Remember the current size, so that the tail below only
+        # shows the output of the new server process.
         log_file = Path(f"{args.name}.server-log.txt")
-        log_file.unlink(missing_ok=True)
+        log_offset = log_file.stat().st_size if log_file.exists() else 0
 
         # Execute the command line.
         try:
@@ -329,7 +331,7 @@ class StartCommand(QleverCommand):
                 f" (Ctrl-C stops following the log, but NOT the server)"
             )
         log.info("")
-        tail_proc = tail_log_file(log_file)
+        tail_proc = tail_log_file(log_file, start_offset=log_offset)
         if tail_proc is None:
             return False
         while not is_qlever_server_alive(args.endpoint_url):

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -606,11 +606,13 @@ def add_memory_options(subparser, index=True, server=True):
 def tail_log_file(
     log_file: Path,
     max_wait_seconds: int = 30,
+    start_offset: int = 0,
 ) -> subprocess.Popen | None:
     """
-    Wait for the log file to appear and start tailing it from the
-    beginning. The old log file should be deleted before calling this
-    function.
+    Wait for the log file to appear and start tailing it from byte offset
+    `start_offset` (with the default of 0, from the beginning). The log file
+    is opened in append mode, so pass the size of the file from before the
+    current run to only show the output of that run.
 
     Returns the tail process, or None if the log file was not created
     within `max_wait_seconds`.
@@ -625,7 +627,7 @@ def tail_log_file(
             return None
         time.sleep(0.1)
         waited += 0.1
-    tail_cmd = f"exec tail -n +1 -f {log_file}"
+    tail_cmd = f"exec tail -c +{start_offset + 1} -f {log_file}"
     return subprocess.Popen(tail_cmd, shell=True)
 
 


### PR DESCRIPTION
So far, `qlever start` deleted the existing server log and started the server with a truncating redirect. In particular, when the server had crashed, its last log messages, which often identify the cause of the crash, were lost on the next start.

Now the server log is opened in append mode and survives restarts. The tail that follows the log until the server is ready starts at the size the file had before the start, so it still only shows the output of the new server process.