### PR TITLE
Make the `qlever` commands independent of the script name

### DIFF
--- a/src/qlever/__init__.py
+++ b/src/qlever/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from importlib import import_module
 from pathlib import Path
 
@@ -11,19 +10,9 @@ def snake_to_camel(str):
     return "".join([w.capitalize() for w in str.replace("-", "_").split("_")])
 
 
-# Get the name of the script (without the path and without the extension).
-script_name = Path(sys.argv[0]).stem
-
-ENGINE_NAMES = {
-    "qlever": "QLever",
-    "qmdb": "MillenniumDB",
-}
-# Default engine_name = script_name without starting 'q' and capitalized
-engine_name = ENGINE_NAMES.get(script_name, script_name[1:].capitalize())
-
 # Each module in `qlever/commands` corresponds to a command. The name
 # of the command is the base name of the module file.
-package_path = Path(__file__).parent.parent / script_name
+package_path = Path(__file__).parent
 command_names = [
     Path(p).stem
     for p in package_path.glob("commands/*.py")
@@ -33,13 +22,11 @@ command_names = [
 # Dynamically load all the command classes and create an object for each.
 command_objects = {}
 for command_name in command_names:
-    module_path = f"{script_name}.commands.{command_name}"
+    module_path = f"qlever.commands.{command_name}"
     try:
         module = import_module(module_path)
     except ImportError as e:
-        raise Exception(
-            f"Could not import module {module_path} for {script_name}: {e}"
-        ) from e
+        raise Exception(f"Could not import module {module_path}: {e}") from e
     # Create an object of the class and store it in the dictionary. For the
     # commands, take - instead of _.
     class_name = snake_to_camel(command_name) + "Command"

--- a/src/qlever/command.py
+++ b/src/qlever/command.py
@@ -9,7 +9,7 @@ from qlever.log import log
 
 class QleverCommand(ABC):
     """
-    Abstract base class for all the commands in `qlever/commands`.
+    Abstract base class for all the commands in `<engine>/commands`.
     """
 
     @abstractmethod
@@ -21,15 +21,13 @@ class QleverCommand(ABC):
         assignments, if any) because we create one object per command and
         initialize each of them.
         """
-        pass
 
     @abstractmethod
     def description(self) -> str:
         """
         A concise description of the command, which will be shown when the user
-        types `qlever --help` or `qlever <command> --help`.
+        asks for the help of the engine or of the command itself.
         """
-        pass
 
     @abstractmethod
     def should_have_qleverfile(self) -> bool:
@@ -39,26 +37,23 @@ class QleverCommand(ABC):
         specified, the command can still be executed if all the required
         arguments are specified on the command line, but there will be warning.
         """
-        pass
 
     @abstractmethod
     def relevant_qleverfile_arguments(self) -> dict[str, list[str]]:
         """
         Retun the arguments relevant for this command. This must be a subset of
-        the names of `all_arguments` defined in `QleverConfig`. Only these
+        the names of `all_arguments` defined in `Qleverfile`. Only these
         arguments can then be used in the `execute` method.
         """
-        pass
 
     @abstractmethod
     def additional_arguments(self, subparser):
         """
         Add additional command-specific arguments (which are not in
-        `QleverConfig.all_arguments` and cannot be specified in the Qleverfile)
+        `Qleverfile.all_arguments` and cannot be specified in the Qleverfile)
         to the given `subparser`. If there are no additional arguments, just
         implement as `pass`.
         """
-        pass
 
     @abstractmethod
     def execute(self, args) -> bool:
@@ -68,7 +63,6 @@ class QleverCommand(ABC):
         the problem could be identified and handled. In all other cases, raise
         a `CommandException`.
         """
-        pass
 
     @staticmethod
     def show(command_description: str, only_show: bool = False):

--- a/src/qlever/command.py
+++ b/src/qlever/command.py
@@ -9,7 +9,7 @@ from qlever.log import log
 
 class QleverCommand(ABC):
     """
-    Abstract base class for all the commands in `<engine>/commands`.
+    Abstract base class for all the commands in `qlever/commands`.
     """
 
     @abstractmethod
@@ -25,8 +25,8 @@ class QleverCommand(ABC):
     @abstractmethod
     def description(self) -> str:
         """
-        A concise description of the command, which will be shown when the user
-        asks for the help of the engine or of the command itself.
+        A concise description of the command, which will be shown in the
+        top-level help and in the help of the command itself.
         """
 
     @abstractmethod
@@ -41,7 +41,7 @@ class QleverCommand(ABC):
     @abstractmethod
     def relevant_qleverfile_arguments(self) -> dict[str, list[str]]:
         """
-        Retun the arguments relevant for this command. This must be a subset of
+        Return the arguments relevant for this command. This must be a subset of
         the names of `all_arguments` defined in `Qleverfile`. Only these
         arguments can then be used in the `execute` method.
         """

--- a/src/qlever/commands/add_text_index.py
+++ b/src/qlever/commands/add_text_index.py
@@ -17,7 +17,7 @@ class AddTextIndexCommand(QleverCommand):
         pass
 
     def description(self) -> str:
-        return "Add text index to an index built with `qlever index`"
+        return "Add text index to an index built with the `index` command"
 
     def should_have_qleverfile(self) -> bool:
         return True

--- a/src/qlever/commands/benchmark_queries.py
+++ b/src/qlever/commands/benchmark_queries.py
@@ -16,12 +16,12 @@ import rdflib
 import yaml
 from termcolor import colored
 
-from qlever import command_objects, engine_name, script_name
+from qlever import command_objects
 from qlever.command import QleverCommand
 from qlever.commands.clear_cache import ClearCacheCommand
-from qlever.commands.ui import dict_to_yaml
 from qlever.log import log, mute_log
 from qlever.util import (
+    dict_to_yaml,
     pretty_printed_query,
     run_command,
     run_curl_command,
@@ -279,7 +279,7 @@ def get_single_int_result(result_file: str) -> int | None:
     return single_int_result
 
 
-def restart_server(start_only: bool = False) -> bool:
+def restart_server(command_prefix: str, start_only: bool = False) -> bool:
     """
     Restart the SPARQL server after the server hangs i.e. doesn't return
     results after timeout + 30s
@@ -288,23 +288,23 @@ def restart_server(start_only: bool = False) -> bool:
     Only useful when Qleverfile in CWD and configured properly i.e. no command
     line args needed to call stop and start commands
     """
-    stop_cmd = f"{script_name} stop"
-    start_cmd = f"{script_name} start"
+    stop_cmd = f"{command_prefix} stop"
+    start_cmd = f"{command_prefix} start"
     if not start_only:
         try:
             run_command(stop_cmd)
             time.sleep(2)
         except Exception as e:
-            log.warning(f"{script_name} process could not be stopped!: {e}")
+            log.warning(f"`{stop_cmd}` failed, server not stopped: {e}")
     try:
         run_command(start_cmd)
         time.sleep(5)
-        log.info(f"Successfully restarted {engine_name} server after hang!")
+        log.info("Successfully restarted the server after hang!")
         return True
     except Exception as e:
         log.warning(
-            f"{script_name} server could not be restarted. This might affect "
-            f"the benchmark process!: {e}"
+            f"`{start_cmd}` failed, server not restarted. This might "
+            f"affect the benchmark process: {e}"
         )
         return False
 
@@ -315,6 +315,7 @@ def resolve_benchmark_metadata(
     yml_name: str | None,
     yml_description: str | None,
     dataset: str | None,
+    command_prefix: str,
 ) -> tuple[str | None, str | None]:
     """
     Resolve benchmark name and description using priority:
@@ -324,7 +325,8 @@ def resolve_benchmark_metadata(
     """
     dataset_name = dataset.capitalize() if dataset else None
     default_description = (
-        f"{dataset_name} benchmark ran using {script_name} benchmark-queries"
+        f"{dataset_name} benchmark ran using "
+        f"{command_prefix} benchmark-queries"
         if dataset_name
         else None
     )
@@ -716,7 +718,7 @@ class BenchmarkQueriesCommand(QleverCommand):
                 "the current engine, and resume execution with the next query. "
                 "NOTE: This only works if all the server parameters for start and "
                 "stop are configured in the Qleverfile and no arguments are needed "
-                f"for the {script_name} start and {script_name} stop commands."
+                "for the start and stop commands."
             ),
         )
 
@@ -879,6 +881,7 @@ class BenchmarkQueriesCommand(QleverCommand):
             yml_name,
             yml_description,
             dataset,
+            args.command_prefix,
         )
 
         # Launch the queries one after the other and for each print: the
@@ -921,7 +924,7 @@ class BenchmarkQueriesCommand(QleverCommand):
                 with mute_log():
                     clear_cache_successful = ClearCacheCommand().execute(args)
                 if not clear_cache_successful:
-                    log.warn("Failed to clear the cache")
+                    log.warning("Failed to clear the cache")
 
             # Remove OFFSET and LIMIT (after the last closing bracket).
             if args.remove_offset_and_limit or args.limit:
@@ -1036,12 +1039,14 @@ class BenchmarkQueriesCommand(QleverCommand):
 
                 # If curl timed out after hitting max_time = 30s
                 if "exit code 28" in str(e) and args.restart_on_hang:
-                    server_restarted = restart_server()
+                    server_restarted = restart_server(args.command_prefix)
                 # If server is not responding and has crashed
                 elif (
                     "exit code 52" in str(e) or "exit code 7" in str(e)
                 ) and args.restart_on_hang:
-                    server_restarted = restart_server(start_only=True)
+                    server_restarted = restart_server(
+                        args.command_prefix, start_only=True
+                    )
 
                 if args.log_level == "DEBUG":
                     traceback.print_exc()

--- a/src/qlever/commands/benchmark_queries.py
+++ b/src/qlever/commands/benchmark_queries.py
@@ -453,9 +453,7 @@ def get_result_yml_query_record(
         headers = []
     if result_size is not None and isinstance(result, str):
         record["result_size"] = result_size
-        result_size = (
-            max_result_size if result_size > max_result_size else result_size
-        )
+        result_size = min(result_size, max_result_size)
         headers, results = get_query_results(
             result, result_size, accept_header
         )

--- a/src/qlever/commands/benchmark_queries.py
+++ b/src/qlever/commands/benchmark_queries.py
@@ -279,7 +279,7 @@ def get_single_int_result(result_file: str) -> int | None:
     return single_int_result
 
 
-def restart_server(command_prefix: str, start_only: bool = False) -> bool:
+def restart_server(main_command_name: str, start_only: bool = False) -> bool:
     """
     Restart the SPARQL server after the server hangs i.e. doesn't return
     results after timeout + 30s
@@ -288,8 +288,8 @@ def restart_server(command_prefix: str, start_only: bool = False) -> bool:
     Only useful when Qleverfile in CWD and configured properly i.e. no command
     line args needed to call stop and start commands
     """
-    stop_cmd = f"{command_prefix} stop"
-    start_cmd = f"{command_prefix} start"
+    stop_cmd = f"{main_command_name} stop"
+    start_cmd = f"{main_command_name} start"
     if not start_only:
         try:
             run_command(stop_cmd)
@@ -315,7 +315,7 @@ def resolve_benchmark_metadata(
     yml_name: str | None,
     yml_description: str | None,
     dataset: str | None,
-    command_prefix: str,
+    main_command_name: str,
 ) -> tuple[str | None, str | None]:
     """
     Resolve benchmark name and description using priority:
@@ -326,7 +326,7 @@ def resolve_benchmark_metadata(
     dataset_name = dataset.capitalize() if dataset else None
     default_description = (
         f"{dataset_name} benchmark ran using "
-        f"{command_prefix} benchmark-queries"
+        f"{main_command_name} benchmark-queries"
         if dataset_name
         else None
     )
@@ -879,7 +879,7 @@ class BenchmarkQueriesCommand(QleverCommand):
             yml_name,
             yml_description,
             dataset,
-            args.command_prefix,
+            args.main_command_name,
         )
 
         # Launch the queries one after the other and for each print: the
@@ -1037,13 +1037,13 @@ class BenchmarkQueriesCommand(QleverCommand):
 
                 # If curl timed out after hitting max_time = 30s
                 if "exit code 28" in str(e) and args.restart_on_hang:
-                    server_restarted = restart_server(args.command_prefix)
+                    server_restarted = restart_server(args.main_command_name)
                 # If server is not responding and has crashed
                 elif (
                     "exit code 52" in str(e) or "exit code 7" in str(e)
                 ) and args.restart_on_hang:
                     server_restarted = restart_server(
-                        args.command_prefix, start_only=True
+                        args.main_command_name, start_only=True
                     )
 
                 if args.log_level == "DEBUG":

--- a/src/qlever/commands/cache_stats.py
+++ b/src/qlever/commands/cache_stats.py
@@ -122,9 +122,9 @@ class CacheStatsCommand(QleverCommand):
             max_key_len = max([len(key) for key, _ in key_value_pairs])
             for key, value in key_value_pairs:
                 if isinstance(value, int) or re.match(r"^\d+$", value):
-                    value = "{:,}".format(int(value))
+                    value = f"{int(value):,}"
                 if re.match(r"^\d+\.\d+$", value):
-                    value = "{:.2f}".format(float(value))
+                    value = f"{float(value):.2f}"
                 log.info(f"{key.ljust(max_key_len)} : {value}")
 
         show_dict_as_table(cache_stats_dict.items())

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -24,8 +24,8 @@ def render_usage_plot(
     settings_json: str,
     plot_max_points: int,
     plot_only: bool,
-    command_prefix: str,
-    engine_display: str,
+    main_command_name: str,
+    engine_display_name: str,
 ) -> Path | None:
     """Render the resource-usage plot.
 
@@ -45,7 +45,7 @@ def render_usage_plot(
             log.info(
                 "To plot the resource-usage log, install matplotlib and "
                 "numpy (`pip install qlever[plot]`), then run "
-                f"`{command_prefix} index --resource-usage-plot-only`."
+                f"`{main_command_name} index --resource-usage-plot-only`."
             )
         return None
     return usage_plot.render_usage_plot(
@@ -53,7 +53,7 @@ def render_usage_plot(
         stxxl_memory=stxxl_memory,
         settings_json=settings_json,
         plot_max_points=plot_max_points,
-        engine_display=engine_display,
+        engine_display_name=engine_display_name,
     )
 
 
@@ -242,8 +242,8 @@ class IndexCommand(QleverCommand):
                 settings_json=args.settings_json,
                 plot_max_points=args.resource_usage_plot_max_points,
                 plot_only=True,
-                command_prefix=args.command_prefix,
-                engine_display=args.engine_display,
+                main_command_name=args.main_command_name,
+                engine_display_name=args.engine_display_name,
             )
             if plot_path is None:
                 return False
@@ -284,7 +284,7 @@ class IndexCommand(QleverCommand):
             )
             log.info("")
             log.info(
-                f"See `{args.command_prefix} index --help` for more "
+                f"See `{args.main_command_name} index --help` for more "
                 "information"
             )
             return False
@@ -364,7 +364,7 @@ class IndexCommand(QleverCommand):
             return False
 
         # Check if all of the input files exist.
-        if not input_files_exist(args.input_files, args.command_prefix):
+        if not input_files_exist(args.input_files, args.main_command_name):
             return False
 
         # Check if index files (name.index.*) already exist.
@@ -421,8 +421,8 @@ class IndexCommand(QleverCommand):
                 settings_json=args.settings_json,
                 plot_max_points=args.resource_usage_plot_max_points,
                 plot_only=False,
-                command_prefix=args.command_prefix,
-                engine_display=args.engine_display,
+                main_command_name=args.main_command_name,
+                engine_display_name=args.engine_display_name,
             )
             if plot_path is not None:
                 log.info(f"Resource-usage plot saved to `{plot_path.name}`")

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -24,6 +24,8 @@ def render_usage_plot(
     settings_json: str,
     plot_max_points: int,
     plot_only: bool,
+    command_prefix: str,
+    engine_display: str,
 ) -> Path | None:
     """Render the resource-usage plot.
 
@@ -43,7 +45,7 @@ def render_usage_plot(
             log.info(
                 "To plot the resource-usage log, install matplotlib and "
                 "numpy (`pip install qlever[plot]`), then run "
-                "`qlever index --resource-usage-plot-only`."
+                f"`{command_prefix} index --resource-usage-plot-only`."
             )
         return None
     return usage_plot.render_usage_plot(
@@ -51,6 +53,7 @@ def render_usage_plot(
         stxxl_memory=stxxl_memory,
         settings_json=settings_json,
         plot_max_points=plot_max_points,
+        engine_display=engine_display,
     )
 
 
@@ -239,6 +242,8 @@ class IndexCommand(QleverCommand):
                 settings_json=args.settings_json,
                 plot_max_points=args.resource_usage_plot_max_points,
                 plot_only=True,
+                command_prefix=args.command_prefix,
+                engine_display=args.engine_display,
             )
             if plot_path is None:
                 return False
@@ -278,7 +283,10 @@ class IndexCommand(QleverCommand):
                 "multiple input streams)"
             )
             log.info("")
-            log.info("See `qlever index --help` for more information")
+            log.info(
+                f"See `{args.command_prefix} index --help` for more "
+                "information"
+            )
             return False
 
         # Add remaining options.
@@ -356,7 +364,7 @@ class IndexCommand(QleverCommand):
             return False
 
         # Check if all of the input files exist.
-        if not input_files_exist(args.input_files):
+        if not input_files_exist(args.input_files, args.command_prefix):
             return False
 
         # Check if index files (name.index.*) already exist.
@@ -413,6 +421,8 @@ class IndexCommand(QleverCommand):
                 settings_json=args.settings_json,
                 plot_max_points=args.resource_usage_plot_max_points,
                 plot_only=False,
+                command_prefix=args.command_prefix,
+                engine_display=args.engine_display,
             )
             if plot_path is not None:
                 log.info(f"Resource-usage plot saved to `{plot_path.name}`")

--- a/src/qlever/commands/index_stats.py
+++ b/src/qlever/commands/index_stats.py
@@ -78,19 +78,20 @@ def compute_durations(
 
     # Compute durations for each indexing phase. Each entry maps a
     # phase name to (duration_in_time_unit, time_unit).
-    durations = {}
-    durations["Parse input"] = (
-        duration([(overall_begin, merge_begin)]),
-        resolved_time_unit,
-    )
-    durations["Build vocabularies"] = (
-        duration([(merge_begin, convert_begin)]),
-        resolved_time_unit,
-    )
-    durations["Convert to global IDs"] = (
-        duration([(convert_begin, convert_end)]),
-        resolved_time_unit,
-    )
+    durations = {
+        "Parse input": (
+            duration([(overall_begin, merge_begin)]),
+            resolved_time_unit,
+        ),
+        "Build vocabularies": (
+            duration([(merge_begin, convert_begin)]),
+            resolved_time_unit,
+        ),
+        "Convert to global IDs": (
+            duration([(convert_begin, convert_end)]),
+            resolved_time_unit,
+        ),
+    }
     for name, perm_begin, perm_end in iter_permutation_phases(
         permutations, normal_end
     ):
@@ -151,9 +152,10 @@ def compute_sizes(
     unit_factor = get_size_unit_factor(size_unit)
     sizes = {k: v / unit_factor for k, v in raw_sizes.items()}
 
-    sizes_to_show = {}
-    sizes_to_show["Files index.*"] = (sizes["index"], size_unit)
-    sizes_to_show["Files vocabulary.*"] = (sizes["vocabulary"], size_unit)
+    sizes_to_show = {
+        "Files index.*": (sizes["index"], size_unit),
+        "Files vocabulary.*": (sizes["vocabulary"], size_unit),
+    }
     if sizes["text"] > 0:
         sizes_to_show["Files text.*"] = (sizes["text"], size_unit)
     sizes_to_show["TOTAL size"] = (sizes["total"], size_unit)

--- a/src/qlever/commands/materialized_view.py
+++ b/src/qlever/commands/materialized_view.py
@@ -19,7 +19,6 @@ class MaterializedViewCommand(QleverCommand):
 
     def __init__(self):
         self.materialized_view_name_regex = r"^[A-Za-z0-9-]+$"
-        pass
 
     def description(self) -> str:
         return (

--- a/src/qlever/commands/serve_evaluation_app.py
+++ b/src/qlever/commands/serve_evaluation_app.py
@@ -164,7 +164,7 @@ class CustomHTTPRequestHandler(SimpleHTTPRequestHandler):
             except Exception as e:
                 self.send_response(500)
                 self.end_headers()
-                self.wfile.write(f"Error loading YAMLs: {e}".encode("utf-8"))
+                self.wfile.write(f"Error loading YAMLs: {e}".encode())
         else:
             super().do_GET()
 

--- a/src/qlever/commands/settings.py
+++ b/src/qlever/commands/settings.py
@@ -19,7 +19,7 @@ class SettingsCommand(QleverCommand):
         pass
 
     def description(self) -> str:
-        return "Show or set server settings (after `qlever start`)"
+        return "Show or set server settings (after the server has started)"
 
     def should_have_qleverfile(self) -> bool:
         return True

--- a/src/qlever/commands/setup_config.py
+++ b/src/qlever/commands/setup_config.py
@@ -50,14 +50,14 @@ class SetupConfigCommand(QleverCommand):
             help="The name of the pre-configured Qleverfile to create",
         )
 
-    def check_qleverfile_exists(self, command_prefix: str) -> bool:
+    def check_qleverfile_exists(self, main_command_name: str) -> bool:
         """Return True if a Qleverfile already exists (and log an error)."""
         if Path("Qleverfile").exists():
             log.error("`Qleverfile` already exists in current directory")
             log.info("")
             log.info(
                 "If you want to create a new Qleverfile using "
-                f"`{command_prefix} setup-config`, delete the existing "
+                f"`{main_command_name} setup-config`, delete the existing "
                 "Qleverfile first"
             )
             return True
@@ -94,7 +94,7 @@ class SetupConfigCommand(QleverCommand):
         if args.show:
             return True
 
-        if self.check_qleverfile_exists(args.command_prefix):
+        if self.check_qleverfile_exists(args.main_command_name):
             return False
 
         # Copy the Qleverfile to the current directory.

--- a/src/qlever/commands/setup_config.py
+++ b/src/qlever/commands/setup_config.py
@@ -50,15 +50,15 @@ class SetupConfigCommand(QleverCommand):
             help="The name of the pre-configured Qleverfile to create",
         )
 
-    def check_qleverfile_exists(self) -> bool:
+    def check_qleverfile_exists(self, command_prefix: str) -> bool:
         """Return True if a Qleverfile already exists (and log an error)."""
         if Path("Qleverfile").exists():
             log.error("`Qleverfile` already exists in current directory")
             log.info("")
             log.info(
                 "If you want to create a new Qleverfile using "
-                "`qlever setup-config`, delete the existing Qleverfile "
-                "first"
+                f"`{command_prefix} setup-config`, delete the existing "
+                "Qleverfile first"
             )
             return True
         return False
@@ -94,7 +94,7 @@ class SetupConfigCommand(QleverCommand):
         if args.show:
             return True
 
-        if self.check_qleverfile_exists():
+        if self.check_qleverfile_exists(args.command_prefix):
             return False
 
         # Copy the Qleverfile to the current directory.

--- a/src/qlever/commands/setup_config.py
+++ b/src/qlever/commands/setup_config.py
@@ -4,7 +4,7 @@ import subprocess
 from os import environ
 from pathlib import Path
 
-import qlever.util as util
+from qlever import util
 from qlever.command import QleverCommand
 from qlever.log import log
 

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -154,7 +154,7 @@ class StartCommand(QleverCommand):
     def description(self) -> str:
         return (
             "Start the QLever server (requires that you have built "
-            "an index with `qlever index` before)"
+            "an index with the `index` command before)"
         )
 
     def should_have_qleverfile(self) -> bool:
@@ -276,8 +276,8 @@ class StartCommand(QleverCommand):
             log.error(f"QLever server already running on {args.endpoint_url}")
             log.info("")
             log.info(
-                "To kill the existing server, use `qlever stop` "
-                "or `qlever start` with option "
+                f"To kill the existing server, use `{args.command_prefix} "
+                f"stop` or `{args.command_prefix} start` with option "
                 "--kill-existing-with-same-port`"
             )
 
@@ -398,7 +398,7 @@ class StartCommand(QleverCommand):
             try:
                 process.wait()
             except KeyboardInterrupt:
-                log.warn("\rCtrl-C pressed, stopping the server ...")
+                log.warning("\rCtrl-C pressed, stopping the server ...")
                 log.info("")
                 process.terminate()
                 # Stop the container process manually

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -167,7 +167,8 @@ def get_runtime_parameters_from_qleverfile(args) -> list[str]:
         qleverfile_path = Path(vars(args).get("qleverfile", "Qleverfile"))
         if not qleverfile_path.is_file():
             return []
-        config = Qleverfile.read(qleverfile_path)
+        # The engine only names default containers, which we don't read here.
+        config = Qleverfile.read(qleverfile_path, vars(args).get("engine", ""))
         value = config.get("server", "set_runtime_parameters", fallback=None)
         return shlex.split(value) if value else []
     except Exception:

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -167,8 +167,11 @@ def get_runtime_parameters_from_qleverfile(args) -> list[str]:
         qleverfile_path = Path(vars(args).get("qleverfile", "Qleverfile"))
         if not qleverfile_path.is_file():
             return []
-        # The engine only names default containers, which we don't read here.
-        config = Qleverfile.read(qleverfile_path, vars(args).get("engine", ""))
+        # The engine is only used for the default container names, which are
+        # not read here.
+        config = Qleverfile.read(
+            qleverfile_path, vars(args).get("engine", "qlever")
+        )
         value = config.get("server", "set_runtime_parameters", fallback=None)
         return shlex.split(value) if value else []
     except Exception:

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -167,10 +167,10 @@ def get_runtime_parameters_from_qleverfile(args) -> list[str]:
         qleverfile_path = Path(vars(args).get("qleverfile", "Qleverfile"))
         if not qleverfile_path.is_file():
             return []
-        # The engine is only used for the default container names, which are
-        # not read here.
+        # The engine short name is only used for the default container names,
+        # which are not read here.
         config = Qleverfile.read(
-            qleverfile_path, vars(args).get("engine", "qlever")
+            qleverfile_path, vars(args).get("engine_short_name", "qlever")
         )
         value = config.get("server", "set_runtime_parameters", fallback=None)
         return shlex.split(value) if value else []
@@ -330,8 +330,8 @@ class StartCommand(QleverCommand):
             log.error(f"QLever server already running on {args.endpoint_url}")
             log.info("")
             log.info(
-                f"To kill the existing server, use `{args.command_prefix} "
-                f"stop` or `{args.command_prefix} start` with option "
+                f"To kill the existing server, use `{args.main_command_name} "
+                f"stop` or `{args.main_command_name} start` with option "
                 "--kill-existing-with-same-port`"
             )
 

--- a/src/qlever/commands/system_info.py
+++ b/src/qlever/commands/system_info.py
@@ -70,7 +70,7 @@ class SystemInfoCommand(QleverCommand):
         is_windows = system == "Windows"
         if is_windows:
             log.warning("Only limited information is gathered on Windows.")
-        script_name = args.command_prefix.split()[0]
+        script_name = args.main_command_name.split()[0]
         log.info(f"Version: {version('qlever')} ({script_name} --version)")
         if is_linux:
             info = platform.freedesktop_os_release()

--- a/src/qlever/commands/system_info.py
+++ b/src/qlever/commands/system_info.py
@@ -70,8 +70,6 @@ class SystemInfoCommand(QleverCommand):
         is_windows = system == "Windows"
         if is_windows:
             log.warning("Only limited information is gathered on Windows.")
-        # `--version` sits on the top-level parser only, so the command to
-        # show it is the first word of the prefix (`qlever`, `qeval`).
         script_name = args.command_prefix.split()[0]
         log.info(f"Version: {version('qlever')} ({script_name} --version)")
         if is_linux:

--- a/src/qlever/commands/system_info.py
+++ b/src/qlever/commands/system_info.py
@@ -69,8 +69,11 @@ class SystemInfoCommand(QleverCommand):
         is_mac = system == "Darwin"
         is_windows = system == "Windows"
         if is_windows:
-            log.warn("Only limited information is gathered on Windows.")
-        log.info(f"Version: {version('qlever')} (qlever --version)")
+            log.warning("Only limited information is gathered on Windows.")
+        # `--version` sits on the top-level parser only, so the command to
+        # show it is the first word of the prefix (`qlever`, `qeval`).
+        script_name = args.command_prefix.split()[0]
+        log.info(f"Version: {version('qlever')} ({script_name} --version)")
         if is_linux:
             info = platform.freedesktop_os_release()
             log.info(f"OS: {platform.system()} ({info['PRETTY_NAME']})")

--- a/src/qlever/commands/ui.py
+++ b/src/qlever/commands/ui.py
@@ -8,34 +8,7 @@ import yaml
 from qlever.command import QleverCommand
 from qlever.containerize import Containerize
 from qlever.log import log
-from qlever.util import is_port_used, run_command
-
-
-# Return a YAML string for the given dictionary. Format values with
-# newlines using the "|" style.
-def dict_to_yaml(dictionary: dict) -> str:
-    """
-    Custom representer for yaml, which uses the "|" style only for
-    multiline strings.
-
-    NOTE: We replace all `\r\n` with `\n` because otherwise the `|` style
-    does not work as expected.
-    """
-
-    class MultiLineDumper(yaml.SafeDumper):
-        def represent_scalar(self, tag, value, style=None):
-            value = value.replace("\r\n", "\n")
-            if isinstance(value, str) and "\n" in value:
-                style = "|"
-            return super().represent_scalar(tag, value, style)
-
-    # Dump as yaml.
-    return yaml.dump(
-        dictionary,
-        sort_keys=False,
-        allow_unicode=True,
-        Dumper=MultiLineDumper,
-    )
+from qlever.util import dict_to_yaml, is_port_used, run_command
 
 
 class UiCommand(QleverCommand):
@@ -98,15 +71,15 @@ class UiCommand(QleverCommand):
         )
         if qlever_is_running_in_container:
             log.error(
-                "The environment variable `QLEVER_OVERRIDE_DISABLE_UI` is set, "
-                "therefore `qlever ui` is not available (it should not be called "
-                "from inside a container)"
+                "The environment variable `QLEVER_OVERRIDE_DISABLE_UI` is "
+                f"set, therefore `{args.command_prefix} ui` is not available "
+                "(it should not be called from inside a container)"
             )
             log.info("")
             if not args.show:
                 log.info(
                     "For your information, showing the commands that are "
-                    "executed when `qlever ui` is available:"
+                    f"executed when `{args.command_prefix} ui` is available:"
                 )
                 log.info("")
 
@@ -265,6 +238,6 @@ class UiCommand(QleverCommand):
         )
         log.info(
             f"You can modify the config file at `{ui_config_file}` "
-            f"and then just run `qlever ui` again"
+            f"and then just run `{args.command_prefix} ui` again"
         )
         return True

--- a/src/qlever/commands/ui.py
+++ b/src/qlever/commands/ui.py
@@ -72,14 +72,14 @@ class UiCommand(QleverCommand):
         if qlever_is_running_in_container:
             log.error(
                 "The environment variable `QLEVER_OVERRIDE_DISABLE_UI` is "
-                f"set, therefore `{args.command_prefix} ui` is not available "
+                f"set, therefore `{args.main_command_name} ui` is not available "
                 "(it should not be called from inside a container)"
             )
             log.info("")
             if not args.show:
                 log.info(
                     "For your information, showing the commands that are "
-                    f"executed when `{args.command_prefix} ui` is available:"
+                    f"executed when `{args.main_command_name} ui` is available:"
                 )
                 log.info("")
 
@@ -238,6 +238,6 @@ class UiCommand(QleverCommand):
         )
         log.info(
             f"You can modify the config file at `{ui_config_file}` "
-            f"and then just run `{args.command_prefix} ui` again"
+            f"and then just run `{args.main_command_name} ui` again"
         )
         return True

--- a/src/qlever/commands/update_wikidata.py
+++ b/src/qlever/commands/update_wikidata.py
@@ -324,7 +324,7 @@ class UpdateWikidataCommand(QleverCommand):
                         delay_str = f"{retry_delay // 60}min"
                     else:
                         delay_str = f"{retry_delay}s"
-                    log.warn(
+                    log.warning(
                         f"{operation_name} failed (attempt {attempt + 1}/{max_retries}): {e}. "
                         f"Retrying in {delay_str} ..."
                     )
@@ -353,19 +353,21 @@ class UpdateWikidataCommand(QleverCommand):
         try:
             yield from source
         except Exception as e:
-            log.warn(f"SSE stream connection lost ({e}), will reconnect ...")
+            log.warning(
+                f"SSE stream connection lost ({e}), will reconnect ..."
+            )
 
     def determine_batch_size_for_cached_update(
         self, offset: int, batch_size: int
     ) -> int | None:
         options = list(Path.cwd().glob(f"update.{offset}.*.sparql"))
         if len(options) == 0:
-            log.warn(
+            log.warning(
                 "Found no cached SPARQL update. Continuing with update stream."
             )
             return None
         elif len(options) > 1:
-            log.warn(
+            log.warning(
                 f"Found {len(options)} candidates for cached SPARQL update. Using {options[0].name}."
             )
         return int(
@@ -539,7 +541,7 @@ class UpdateWikidataCommand(QleverCommand):
 
         # Special handling of Ctrl+C, see `handle_ctrl_c` above.
         signal.signal(signal.SIGINT, self.handle_ctrl_c)
-        log.warn("Press Ctrl+C to finish and exit gracefully")
+        log.warning("Press Ctrl+C to finish and exit gracefully")
         log.info("")
 
         # If no `--offset` is provided, try to get the offset from
@@ -584,7 +586,7 @@ class UpdateWikidataCommand(QleverCommand):
                     )
                 args.offset = offset
             except KeyboardInterrupt:
-                log.warn(
+                log.warning(
                     "\rCtrl+C pressed while determine current state, exiting"
                 )
                 return True
@@ -648,7 +650,7 @@ class UpdateWikidataCommand(QleverCommand):
                 wait_before_next_batch = False
                 self.ctrl_c_pressed.wait(args.wait_between_batches)
             if self.ctrl_c_pressed.is_set():
-                log.warn(
+                log.warning(
                     "\rCtrl+C pressed while waiting in between batches, "
                     "exiting"
                 )
@@ -686,7 +688,7 @@ class UpdateWikidataCommand(QleverCommand):
                     args.num_retries,
                 )
             except KeyboardInterrupt:
-                log.warn(
+                log.warning(
                     "\rCtrl+C pressed while while connecting to stream, "
                     "exiting"
                 )
@@ -732,7 +734,7 @@ class UpdateWikidataCommand(QleverCommand):
                         args.num_retries,
                     )
                 except KeyboardInterrupt:
-                    log.warn(
+                    log.warning(
                         "\rCtrl+C pressed while while verifying state, exiting"
                     )
                     break
@@ -907,7 +909,7 @@ class UpdateWikidataCommand(QleverCommand):
                                 and entity_id in delete_entity_ids
                             ):
                                 if args.verbose == "yes":
-                                    log.warn(
+                                    log.warning(
                                         f"Encountered operation that adds data for "
                                         f"an entity ID ({entity_id}) that was deleted "
                                         f"earlier in this batch; finishing batch and "
@@ -936,7 +938,7 @@ class UpdateWikidataCommand(QleverCommand):
                                 and current_batch_size > 0
                             ):
                                 if args.verbose == "yes":
-                                    log.warn(
+                                    log.warning(
                                         f"Encountered message with date {date}, which is within "
                                         f"{args.lag_seconds} "
                                         f"second{'s' if args.lag_seconds > 1 else ''} "
@@ -955,7 +957,7 @@ class UpdateWikidataCommand(QleverCommand):
                                 and date >= args.until
                                 and current_batch_size > 0
                             ):
-                                log.warn(
+                                log.warning(
                                     f"Reached --until date {args.until} "
                                     f"(message date: {date}), that's it folks"
                                 )
@@ -1169,7 +1171,7 @@ class UpdateWikidataCommand(QleverCommand):
                         # end of the inner event loop so that always at least one
                         # message is processed).
                         if self.ctrl_c_pressed.is_set():
-                            log.warn(
+                            log.warning(
                                 "\rCtrl+C pressed while processing a batch, "
                                 "finishing it and exiting"
                             )
@@ -1311,12 +1313,12 @@ class UpdateWikidataCommand(QleverCommand):
                 result = run_command(curl_cmd, return_output=True)
             except Exception:
                 if self.ctrl_c_pressed.is_set():
-                    log.warn(
+                    log.warning(
                         "\r  \nCtrl+C pressed while executing update, exiting"
                     )
                     return True
                 else:
-                    log.warn(
+                    log.warning(
                         "\r  \nUpdate request failed; will reconnect and retry"
                     )
                     event_id_for_next_batch = [
@@ -1526,7 +1528,7 @@ class UpdateWikidataCommand(QleverCommand):
                         )
 
                 except Exception as e:
-                    log.warn(
+                    log.warning(
                         f"Error extracting statistics: {e}, "
                         f"curl command was: {curl_cmd}"
                     )

--- a/src/qlever/config.py
+++ b/src/qlever/config.py
@@ -10,9 +10,16 @@ from pathlib import Path
 import argcomplete
 from termcolor import colored
 
-from qlever import command_objects, engine_name, script_name
+from qlever import command_objects
 from qlever.log import log, log_levels
 from qlever.qleverfile import Qleverfile
+
+# The engine name (used for the container names), what the user types before a
+# command, and the human-readable name of the engine. These are provided to all
+# commands via `args`, see `parse_args` below.
+ENGINE = "qlever"
+COMMAND_PREFIX = "qlever"
+ENGINE_DISPLAY = "QLever"
 
 
 # Simple exception class for configuration errors (the class need not do
@@ -149,7 +156,7 @@ class QleverConfig:
                 f"To enable autocompletion, run the following command, "
                 f"and consider adding it to your `.bashrc` or `.zshrc`:"
                 f"\n\n"
-                f'eval "$(register-python-argcomplete {script_name})"'
+                f'eval "$(register-python-argcomplete {COMMAND_PREFIX})"'
                 f" && export QLEVER_ARGCOMPLETE_ENABLED=1"
             )
             log.info("")
@@ -197,7 +204,7 @@ class QleverConfig:
         # we then parse the Qleverfile or not.
         if qleverfile_exists and not autocomplete_mode:
             try:
-                qleverfile_config = Qleverfile.read(qleverfile_path, "qlever")
+                qleverfile_config = Qleverfile.read(qleverfile_path, ENGINE)
             except Exception as e:
                 log.info("")
                 log.error(f"Error parsing Qleverfile `{qleverfile_path}`: {e}")
@@ -212,29 +219,25 @@ class QleverConfig:
         # an object of each class is created and stored in `command_objects`.
         parser = argparse.ArgumentParser(
             description=colored(
-                f"This is the {script_name} command line tool, "
-                f"it's all you need to work with {engine_name}",
+                f"This is the {COMMAND_PREFIX} command line tool, "
+                f"it's all you need to work with {ENGINE_DISPLAY}",
                 attrs=["bold"],
             )
         )
-        # `engine` keys machine-facing things like container names,
-        # `command_prefix` is what the user types before a command, and
-        # `engine_display` is the human-readable name.
         parser.set_defaults(
-            engine="qlever",
-            engine_display="QLever",
-            command_prefix="qlever",
+            engine=ENGINE,
+            engine_display=ENGINE_DISPLAY,
+            command_prefix=COMMAND_PREFIX,
         )
-        if script_name == "qlever":
-            parser.add_argument(
-                "--version",
-                action="version",
-                version=f"%(prog)s {version('qlever')}",
-            )
+        parser.add_argument(
+            "--version",
+            action="version",
+            version=f"%(prog)s {version('qlever')}",
+        )
         add_qleverfile_option(parser)
         subparsers = parser.add_subparsers(dest="command")
         subparsers.required = True
-        all_args = Qleverfile.all_arguments("qlever")
+        all_args = Qleverfile.all_arguments(COMMAND_PREFIX)
         for command_name, command_object in command_objects.items():
             self.add_subparser_for_command(
                 subparsers,

--- a/src/qlever/config.py
+++ b/src/qlever/config.py
@@ -14,12 +14,13 @@ from qlever import command_objects
 from qlever.log import log, log_levels
 from qlever.qleverfile import Qleverfile
 
-# The engine name (used for the container names), what the user types before a
-# command, and the human-readable name of the engine. These are provided to all
-# commands via `args`, see `parse_args` below.
-ENGINE = "qlever"
-COMMAND_PREFIX = "qlever"
-ENGINE_DISPLAY = "QLever"
+# The short name of the engine (used for the container names), the name of the
+# engine as shown to the user, and the name of the main command (what the user
+# types before a command). These are provided to all commands via `args`, see
+# `parse_args` below.
+ENGINE_SHORT_NAME = "qlever"
+MAIN_COMMAND_NAME = "qlever"
+ENGINE_DISPLAY_NAME = "QLever"
 
 
 # Simple exception class for configuration errors (the class need not do
@@ -156,7 +157,7 @@ class QleverConfig:
                 f"To enable autocompletion, run the following command, "
                 f"and consider adding it to your `.bashrc` or `.zshrc`:"
                 f"\n\n"
-                f'eval "$(register-python-argcomplete {COMMAND_PREFIX})"'
+                f'eval "$(register-python-argcomplete {MAIN_COMMAND_NAME})"'
                 f" && export QLEVER_ARGCOMPLETE_ENABLED=1"
             )
             log.info("")
@@ -204,7 +205,9 @@ class QleverConfig:
         # we then parse the Qleverfile or not.
         if qleverfile_exists and not autocomplete_mode:
             try:
-                qleverfile_config = Qleverfile.read(qleverfile_path, ENGINE)
+                qleverfile_config = Qleverfile.read(
+                    qleverfile_path, ENGINE_SHORT_NAME
+                )
             except Exception as e:
                 log.info("")
                 log.error(f"Error parsing Qleverfile `{qleverfile_path}`: {e}")
@@ -219,15 +222,15 @@ class QleverConfig:
         # an object of each class is created and stored in `command_objects`.
         parser = argparse.ArgumentParser(
             description=colored(
-                f"This is the {COMMAND_PREFIX} command line tool, "
-                f"it's all you need to work with {ENGINE_DISPLAY}",
+                f"This is the {MAIN_COMMAND_NAME} command line tool, "
+                f"it's all you need to work with {ENGINE_DISPLAY_NAME}",
                 attrs=["bold"],
             )
         )
         parser.set_defaults(
-            engine=ENGINE,
-            engine_display=ENGINE_DISPLAY,
-            command_prefix=COMMAND_PREFIX,
+            engine_short_name=ENGINE_SHORT_NAME,
+            engine_display_name=ENGINE_DISPLAY_NAME,
+            main_command_name=MAIN_COMMAND_NAME,
         )
         parser.add_argument(
             "--version",
@@ -237,7 +240,7 @@ class QleverConfig:
         add_qleverfile_option(parser)
         subparsers = parser.add_subparsers(dest="command")
         subparsers.required = True
-        all_args = Qleverfile.all_arguments(COMMAND_PREFIX)
+        all_args = Qleverfile.all_arguments(MAIN_COMMAND_NAME)
         for command_name, command_object in command_objects.items():
             self.add_subparser_for_command(
                 subparsers,

--- a/src/qlever/config.py
+++ b/src/qlever/config.py
@@ -145,7 +145,7 @@ class QleverConfig:
         argcomplete_enabled = os.environ.get("QLEVER_ARGCOMPLETE_ENABLED")
         if not argcomplete_enabled and not argcomplete_check_off:
             log.info("")
-            log.warn(
+            log.warning(
                 f"To enable autocompletion, run the following command, "
                 f"and consider adding it to your `.bashrc` or `.zshrc`:"
                 f"\n\n"
@@ -197,7 +197,7 @@ class QleverConfig:
         # we then parse the Qleverfile or not.
         if qleverfile_exists and not autocomplete_mode:
             try:
-                qleverfile_config = Qleverfile.read(qleverfile_path)
+                qleverfile_config = Qleverfile.read(qleverfile_path, "qlever")
             except Exception as e:
                 log.info("")
                 log.error(f"Error parsing Qleverfile `{qleverfile_path}`: {e}")
@@ -217,6 +217,14 @@ class QleverConfig:
                 attrs=["bold"],
             )
         )
+        # `engine` keys machine-facing things like container names,
+        # `command_prefix` is what the user types before a command, and
+        # `engine_display` is the human-readable name.
+        parser.set_defaults(
+            engine="qlever",
+            engine_display="QLever",
+            command_prefix="qlever",
+        )
         if script_name == "qlever":
             parser.add_argument(
                 "--version",
@@ -226,7 +234,7 @@ class QleverConfig:
         add_qleverfile_option(parser)
         subparsers = parser.add_subparsers(dest="command")
         subparsers.required = True
-        all_args = Qleverfile.all_arguments()
+        all_args = Qleverfile.all_arguments("qlever")
         for command_name, command_object in command_objects.items():
             self.add_subparser_for_command(
                 subparsers,

--- a/src/qlever/containerize.py
+++ b/src/qlever/containerize.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import shlex
 import subprocess
-from typing import Optional
 
 from qlever.log import log
 from qlever.util import get_random_string, run_command
@@ -39,7 +38,7 @@ class Containerize:
         container_name: str,
         volumes: list[tuple[str, str]] = [],
         ports: list[tuple[int, int]] = [],
-        working_directory: Optional[str] = None,
+        working_directory: str | None = None,
         use_bash: bool = True,
     ) -> str:
         """
@@ -148,7 +147,7 @@ class Containerize:
             return False
 
     @staticmethod
-    def run_in_container(cmd: str, args) -> Optional[str]:
+    def run_in_container(cmd: str, args) -> str | None:
         """
         Run an arbitrary command in the qlever container and return its output.
         """

--- a/src/qlever/qlever_main.py
+++ b/src/qlever/qlever_main.py
@@ -48,7 +48,7 @@ def main():
         if not command_successful:
             exit(1)
     except KeyboardInterrupt:
-        log.warn("\rCtrl-C pressed, exiting ...")
+        log.warning("\rCtrl-C pressed, exiting ...")
         log.info("")
         exit(1)
     except Exception as e:

--- a/src/qlever/qlever_main.py
+++ b/src/qlever/qlever_main.py
@@ -13,7 +13,7 @@ import traceback
 
 from termcolor import colored
 
-from qlever import command_objects, script_name
+from qlever import command_objects
 from qlever.config import ConfigException, QleverConfig
 from qlever.log import log, log_levels
 
@@ -60,7 +60,7 @@ def main():
         )
         match_error = re.search(r"object has no attribute '(.+)'", str(e))
         match_trace = re.search(
-            rf"({script_name}/commands/.+\.py)\", line (\d+)",
+            r"(qlever/commands/.+\.py)\", line (\d+)",
             traceback.format_exc(),
         )
         if isinstance(e, AttributeError) and match_error and match_trace:

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -5,10 +5,8 @@ import socket
 import subprocess
 from argparse import ArgumentTypeError
 from configparser import ConfigParser, ExtendedInterpolation, RawConfigParser
-from importlib import import_module
 from pathlib import Path
 
-from qlever import script_name
 from qlever.containerize import Containerize
 from qlever.log import log
 from qlever.util import positive_int
@@ -85,7 +83,7 @@ class Qleverfile:
     ]
 
     @staticmethod
-    def all_arguments():
+    def all_arguments(command_prefix: str) -> dict:
         """
         Define all possible parameters. A value of `None` means that there is
         no default value.
@@ -379,7 +377,8 @@ class Qleverfile:
             default="manual",
             help="When to rebuild the index from the current data (including "
             'updates): "manual" (only when explicitly requested via '
-            '`qlever rebuild-index`) or "automatic:min:max:fraction" (additionally '
+            f"`{command_prefix} rebuild-index`) or "
+            '"automatic:min:max:fraction" (additionally '
             "rebuild automatically in the background once the number of delta "
             "triples reaches the given `fraction` of the number of index "
             "triples, but never below `min` and always at `max`, "
@@ -416,7 +415,7 @@ class Qleverfile:
             choices=["yes", "no"],
             default="yes",
             help="Whether to use the patterns precomputed during the index "
-            "build (see `qlever index --help` for their utility)",
+            f"build (see `{command_prefix} index --help` for their utility)",
         )
         server_args["metrics_log"] = arg(
             "--metrics-log",
@@ -443,7 +442,7 @@ class Qleverfile:
             choices=["yes", "no"],
             default="no",
             help="Whether to use the text index (requires that one was "
-            "built, see `qlever index`)",
+            f"built, see `{command_prefix} index`)",
         )
         server_args["preload_materialized_views"] = arg(
             "-l",
@@ -457,8 +456,8 @@ class Qleverfile:
             "--warmup-cmd",
             type=str,
             help="Command executed after the server has started "
-            " (executed as part of `qlever start` unless "
-            " `--no-warmup` is specified, or with `qlever warmup`)",
+            f" (executed as part of `{command_prefix} start` unless "
+            f" `--no-warmup` is specified, or with `{command_prefix} warmup`)",
         )
         server_args["enable_metrics"] = arg(
             "--enable-metrics",
@@ -487,12 +486,12 @@ class Qleverfile:
         runtime_args["index_container"] = arg(
             "--index-container",
             type=str,
-            help=f"The name of the container used by `{script_name} index`",
+            help=f"The name of the container used by `{command_prefix} index`",
         )
         runtime_args["server_container"] = arg(
             "--server-container",
             type=str,
-            help=f"The name of the container used by `{script_name} start`",
+            help=f"The name of the container used by `{command_prefix} start`",
         )
         runtime_args["restart_policy"] = arg(
             "--restart-policy",
@@ -508,7 +507,9 @@ class Qleverfile:
             "--ui-port",
             type=int,
             default=8176,
-            help="The port of the Qlever UI when running `qlever ui`",
+            help=(
+                f"The port of the Qlever UI when running `{command_prefix} ui`"
+            ),
         )
         ui_args["ui_config"] = arg(
             "--ui-config",
@@ -522,36 +523,29 @@ class Qleverfile:
             type=str,
             choices=Containerize.supported_systems(),
             default="docker",
-            help="Which container system to use for `qlever ui`"
-            " (unlike for `qlever index` and `qlever start`, "
-            ' "native" is not yet supported here)',
+            help=(
+                f"Which container system to use for `{command_prefix} ui` "
+                f"(unlike for `{command_prefix} index` and "
+                f'`{command_prefix} start`, "native" is not yet supported '
+                "here)"
+            ),
         )
         ui_args["ui_image"] = arg(
             "--ui-image",
             type=str,
             default="docker.io/adfreiburg/qlever-ui",
-            help="The name of the image used for `qlever ui`",
+            help=f"The name of the image used for `{command_prefix} ui`",
         )
         ui_args["ui_container"] = arg(
             "--ui-container",
             type=str,
-            help="The name of the container used for `qlever ui`",
+            help=f"The name of the container used for `{command_prefix} ui`",
         )
-
-        engine_args_module_path = f"{script_name}.qleverfile"
-        try:
-            if script_name != "qlever":
-                module = import_module(engine_args_module_path)
-                module.qleverfile_args(all_args)
-        except (ImportError, AttributeError) as e:
-            log.debug(
-                f"Could not import module {engine_args_module_path}: {e}"
-            )
 
         return all_args
 
     @staticmethod
-    def read(qleverfile_path):
+    def read(qleverfile_path: Path, engine: str) -> ConfigParser:
         """
         Read the given Qleverfile (the function assumes that it exists) and
         return a `ConfigParser` object with all the options and their values.
@@ -604,21 +598,22 @@ class Qleverfile:
                 config[section] = {}
 
         # Add default values that are based on other values.
+        index = config["index"]
+        server = config["server"]
         if "name" in config["data"]:
             name = config["data"]["name"]
             runtime = config["runtime"]
             if "server_container" not in runtime:
-                runtime["server_container"] = f"{script_name}.server.{name}"
+                runtime["server_container"] = f"{engine}.server.{name}"
             if "index_container" not in runtime:
-                runtime["index_container"] = f"{script_name}.index.{name}"
+                runtime["index_container"] = f"{engine}.index.{name}"
             if "ui_container" not in config["ui"]:
                 config["ui"]["ui_container"] = f"qlever.ui.{name}"
-            index = config["index"]
             if "text_words_file" not in index:
                 index["text_words_file"] = f"{name}.wordsfile.tsv"
             if "text_docs_file" not in index:
                 index["text_docs_file"] = f"{name}.docsfile.tsv"
-            server = config["server"]
+
         if index.get("text_index", "none") != "none":
             server["use_text_index"] = "yes"
         if index.get("only_pso_and_pos_permutations", "false") == "true":

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -83,7 +83,7 @@ class Qleverfile:
     ]
 
     @staticmethod
-    def all_arguments(command_prefix: str) -> dict:
+    def all_arguments(main_command_name: str) -> dict:
         """
         Define all possible parameters. A value of `None` means that there is
         no default value.
@@ -377,7 +377,7 @@ class Qleverfile:
             default="manual",
             help="When to rebuild the index from the current data (including "
             'updates): "manual" (only when explicitly requested via '
-            f"`{command_prefix} rebuild-index`) or "
+            f"`{main_command_name} rebuild-index`) or "
             '"automatic:min:max:fraction" (additionally '
             "rebuild automatically in the background once the number of delta "
             "triples reaches the given `fraction` of the number of index "
@@ -412,7 +412,7 @@ class Qleverfile:
             "server startup, each in the form `name=value` (for the list of "
             "runtime parameters and their default values, run "
             "`qlever-server --set-runtime-parameter help`; they can also be "
-            f"changed while the server is running, via `{command_prefix} "
+            f"changed while the server is running, via `{main_command_name} "
             "settings`); "
             "parameters given on the command line are merged with those "
             "from the Qleverfile and take precedence for the same name",
@@ -429,7 +429,7 @@ class Qleverfile:
             choices=["yes", "no"],
             default="yes",
             help="Whether to use the patterns precomputed during the index "
-            f"build (see `{command_prefix} index --help` for their utility)",
+            f"build (see `{main_command_name} index --help` for their utility)",
         )
         server_args["metrics_log"] = arg(
             "--metrics-log",
@@ -456,7 +456,7 @@ class Qleverfile:
             choices=["yes", "no"],
             default="no",
             help="Whether to use the text index (requires that one was "
-            f"built, see `{command_prefix} index`)",
+            f"built, see `{main_command_name} index`)",
         )
         server_args["preload_materialized_views"] = arg(
             "-l",
@@ -470,8 +470,8 @@ class Qleverfile:
             "--warmup-cmd",
             type=str,
             help="Command executed after the server has started "
-            f" (executed as part of `{command_prefix} start` unless "
-            f" `--no-warmup` is specified, or with `{command_prefix} warmup`)",
+            f" (executed as part of `{main_command_name} start` unless "
+            f" `--no-warmup` is specified, or with `{main_command_name} warmup`)",
         )
         server_args["enable_metrics"] = arg(
             "--enable-metrics",
@@ -500,12 +500,12 @@ class Qleverfile:
         runtime_args["index_container"] = arg(
             "--index-container",
             type=str,
-            help=f"The name of the container used by `{command_prefix} index`",
+            help=f"The name of the container used by `{main_command_name} index`",
         )
         runtime_args["server_container"] = arg(
             "--server-container",
             type=str,
-            help=f"The name of the container used by `{command_prefix} start`",
+            help=f"The name of the container used by `{main_command_name} start`",
         )
         runtime_args["restart_policy"] = arg(
             "--restart-policy",
@@ -522,7 +522,7 @@ class Qleverfile:
             type=int,
             default=8176,
             help=(
-                f"The port of the Qlever UI when running `{command_prefix} ui`"
+                f"The port of the Qlever UI when running `{main_command_name} ui`"
             ),
         )
         ui_args["ui_config"] = arg(
@@ -538,9 +538,9 @@ class Qleverfile:
             choices=Containerize.supported_systems(),
             default="docker",
             help=(
-                f"Which container system to use for `{command_prefix} ui` "
-                f"(unlike for `{command_prefix} index` and "
-                f'`{command_prefix} start`, "native" is not yet supported '
+                f"Which container system to use for `{main_command_name} ui` "
+                f"(unlike for `{main_command_name} index` and "
+                f'`{main_command_name} start`, "native" is not yet supported '
                 "here)"
             ),
         )
@@ -548,18 +548,18 @@ class Qleverfile:
             "--ui-image",
             type=str,
             default="docker.io/adfreiburg/qlever-ui",
-            help=f"The name of the image used for `{command_prefix} ui`",
+            help=f"The name of the image used for `{main_command_name} ui`",
         )
         ui_args["ui_container"] = arg(
             "--ui-container",
             type=str,
-            help=f"The name of the container used for `{command_prefix} ui`",
+            help=f"The name of the container used for `{main_command_name} ui`",
         )
 
         return all_args
 
     @staticmethod
-    def read(qleverfile_path: Path, engine: str) -> ConfigParser:
+    def read(qleverfile_path: Path, engine_short_name: str) -> ConfigParser:
         """
         Read the given Qleverfile (the function assumes that it exists) and
         return a `ConfigParser` object with all the options and their values.
@@ -618,9 +618,13 @@ class Qleverfile:
             name = config["data"]["name"]
             runtime = config["runtime"]
             if "server_container" not in runtime:
-                runtime["server_container"] = f"{engine}.server.{name}"
+                runtime["server_container"] = (
+                    f"{engine_short_name}.server.{name}"
+                )
             if "index_container" not in runtime:
-                runtime["index_container"] = f"{engine}.index.{name}"
+                runtime["index_container"] = (
+                    f"{engine_short_name}.index.{name}"
+                )
             if "ui_container" not in config["ui"]:
                 config["ui"]["ui_container"] = f"qlever.ui.{name}"
             if "text_words_file" not in index:

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -629,7 +629,6 @@ class Qleverfile:
             log.warning(
                 "Could not get the hostname, using `localhost` as default"
             )
-            pass
 
         # Return the parsed Qleverfile with the added inherited values.
         return config

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -412,7 +412,8 @@ class Qleverfile:
             "server startup, each in the form `name=value` (for the list of "
             "runtime parameters and their default values, run "
             "`qlever-server --set-runtime-parameter help`; they can also be "
-            "changed while the server is running, via `qlever settings`); "
+            f"changed while the server is running, via `{command_prefix} "
+            "settings`); "
             "parameters given on the command line are merged with those "
             "from the Qleverfile and take precedence for the same name",
         )

--- a/src/qlever/resource_usage/usage_plot.py
+++ b/src/qlever/resource_usage/usage_plot.py
@@ -11,7 +11,7 @@ import numpy as np
 import psutil
 
 matplotlib.use("Agg")
-from matplotlib import pyplot as plt  # noqa: E402
+from matplotlib import pyplot as plt
 
 from qlever.log import log
 from qlever.util import (

--- a/src/qlever/resource_usage/usage_plot.py
+++ b/src/qlever/resource_usage/usage_plot.py
@@ -307,7 +307,7 @@ def write_usage_plot(
 
 def render_usage_plot(
     dataset: str,
-    engine_display: str,
+    engine_display_name: str,
     stxxl_memory: str = "",
     settings_json: str = "{}",
     output_dir: Path | None = None,
@@ -337,7 +337,7 @@ def render_usage_plot(
             stxxl_memory=stxxl_memory,
             settings_json=settings_json,
             out_path=plot_path,
-            title=f"{engine_display} index build: {dataset}",
+            title=f"{engine_display_name} index build: {dataset}",
             plot_max_points=plot_max_points,
         )
     except Exception as error:

--- a/src/qlever/resource_usage/usage_plot.py
+++ b/src/qlever/resource_usage/usage_plot.py
@@ -13,7 +13,6 @@ import psutil
 matplotlib.use("Agg")
 from matplotlib import pyplot as plt  # noqa: E402
 
-from qlever import engine_name
 from qlever.log import log
 from qlever.util import (
     iter_permutation_phases,
@@ -308,6 +307,7 @@ def write_usage_plot(
 
 def render_usage_plot(
     dataset: str,
+    engine_display: str,
     stxxl_memory: str = "",
     settings_json: str = "{}",
     output_dir: Path | None = None,
@@ -337,7 +337,7 @@ def render_usage_plot(
             stxxl_memory=stxxl_memory,
             settings_json=settings_json,
             out_path=plot_path,
-            title=f"{engine_name} index build: {dataset}",
+            title=f"{engine_display} index build: {dataset}",
             plot_max_points=plot_max_points,
         )
     except Exception as error:

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -17,9 +17,30 @@ from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
 import psutil
+import yaml
 
-from qlever import script_name
 from qlever.log import log
+
+
+def dict_to_yaml(dictionary: dict) -> str:
+    """
+    Dump a dict to YAML, using the `|` block style for multiline strings.
+    """
+
+    class MultiLineDumper(yaml.SafeDumper):
+        def represent_scalar(self, tag, value, style=None):
+            # The `|` style does not work as expected with `\r\n`.
+            value = value.replace("\r\n", "\n")
+            if isinstance(value, str) and "\n" in value:
+                style = "|"
+            return super().represent_scalar(tag, value, style)
+
+    return yaml.dump(
+        dictionary,
+        sort_keys=False,
+        allow_unicode=True,
+        Dumper=MultiLineDumper,
+    )
 
 
 def get_total_file_size(
@@ -404,7 +425,7 @@ def binary_exists(binary: str, cmd_arg: str, args) -> bool:
 
     is_containerized = args.system in Containerize.supported_systems()
     cmd = f"{binary} --help"
-    if is_containerized and script_name == "qlever":
+    if is_containerized and args.engine == "qlever":
         cmd = Containerize().containerize_command(
             cmd,
             args.system,
@@ -452,7 +473,7 @@ def is_server_alive(url: str) -> bool:
         return False
 
 
-def input_files_exist(input_files: str) -> bool:
+def input_files_exist(input_files: str, command_prefix: str) -> bool:
     """
     Check if all of the input files exist in current working directory.
     """
@@ -461,7 +482,7 @@ def input_files_exist(input_files: str) -> bool:
             log.error(f'No file matching "{pattern}" found')
             log.info("")
             log.info(
-                f"Did you call `{script_name} get-data`? If you did, "
+                f"Did you call `{command_prefix} get-data`? If you did, "
                 "check GET_DATA_CMD and INPUT_FILES in the Qleverfile"
             )
             return False

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -425,7 +425,7 @@ def binary_exists(binary: str, cmd_arg: str, args) -> bool:
 
     is_containerized = args.system in Containerize.supported_systems()
     cmd = f"{binary} --help"
-    if is_containerized and args.engine == "qlever":
+    if is_containerized and args.engine_short_name == "qlever":
         cmd = Containerize().containerize_command(
             cmd,
             args.system,
@@ -473,7 +473,7 @@ def is_server_alive(url: str) -> bool:
         return False
 
 
-def input_files_exist(input_files: str, command_prefix: str) -> bool:
+def input_files_exist(input_files: str, main_command_name: str) -> bool:
     """
     Check if all of the input files exist in current working directory.
     """
@@ -482,7 +482,7 @@ def input_files_exist(input_files: str, command_prefix: str) -> bool:
             log.error(f'No file matching "{pattern}" found')
             log.info("")
             log.info(
-                f"Did you call `{command_prefix} get-data`? If you did, "
+                f"Did you call `{main_command_name} get-data`? If you did, "
                 "check GET_DATA_CMD and INPUT_FILES in the Qleverfile"
             )
             return False

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -14,7 +14,7 @@ import time
 from collections.abc import Iterator
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 
 import psutil
 import yaml
@@ -68,7 +68,7 @@ def run_command(
     show_output: bool = False,
     show_stderr: bool = False,
     use_popen: bool = False,
-) -> Optional[str | subprocess.Popen]:
+) -> str | subprocess.Popen | None:
     """
     Run the given command and throw an exception if the exit code is non-zero.
     If `return_output` is `True`, return what the command wrote to `stdout`.

--- a/test/qlever/commands/test_benchmark_queries_methods.py
+++ b/test/qlever/commands/test_benchmark_queries_methods.py
@@ -463,7 +463,7 @@ def test_parse_queries_tsv_command_failure(mock_command):
 )
 def test_resolve_benchmark_metadata(case):
     name, desc = resolve_benchmark_metadata(
-        *case["cli"], *case["yml"], case["dataset"]
+        *case["cli"], *case["yml"], case["dataset"], "qlever"
     )
     exp_name, exp_desc = case["expected"]
     assert name == exp_name

--- a/test/qlever/commands/test_index_execute.py
+++ b/test/qlever/commands/test_index_execute.py
@@ -335,7 +335,7 @@ class TestIndexCommand(unittest.TestCase):
         args.resource_usage_plot_only = False
         args.cat_input_files = True
         args.multi_input_json = True
-        args.command_prefix = "qlever"
+        args.main_command_name = "qlever"
 
         # Instantiate IndexCommand and execute the function
         result = IndexCommand().execute(args)

--- a/test/qlever/commands/test_index_execute.py
+++ b/test/qlever/commands/test_index_execute.py
@@ -335,6 +335,7 @@ class TestIndexCommand(unittest.TestCase):
         args.resource_usage_plot_only = False
         args.cat_input_files = True
         args.multi_input_json = True
+        args.command_prefix = "qlever"
 
         # Instantiate IndexCommand and execute the function
         result = IndexCommand().execute(args)

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -11,7 +11,7 @@ class TestStartCommand(unittest.TestCase):
             StartCommand().description(),
             "Start the "
             "QLever server (requires that you have built "
-            "an index with `qlever index` before)",
+            "an index with the `index` command before)",
         )
 
     def test_should_have_qleverfile(self):
@@ -94,7 +94,7 @@ class TestStartCommand(unittest.TestCase):
         self.assertEqual(argument_help, "Do not execute the warmup command")
 
     def test_preload_materialized_views_qleverfile_argument(self):
-        args, kwargs = Qleverfile.all_arguments()["server"][
+        args, kwargs = Qleverfile.all_arguments("qlever")["server"][
             "preload_materialized_views"
         ]
 

--- a/test/qlever/resource_usage/test_usage_plot.py
+++ b/test/qlever/resource_usage/test_usage_plot.py
@@ -210,7 +210,7 @@ def test_compute_phase_boundaries_skips_incomplete_phase(tmp_path):
 
 
 def test_render_usage_plot_missing_tsv(tmp_path):
-    assert render_usage_plot("missing", output_dir=tmp_path) is None
+    assert render_usage_plot("missing", "QLever", output_dir=tmp_path) is None
 
 
 def test_render_usage_plot_header_only_tsv_renders_nothing(tmp_path):
@@ -218,7 +218,7 @@ def test_render_usage_plot_header_only_tsv_renders_nothing(tmp_path):
     # or leave a PNG behind.
     tsv_path = tmp_path / "data.index.resource-usage-log.tsv"
     tsv_path.write_text("elapsed_s\trss\tcpu_percent\n")
-    assert render_usage_plot("data", output_dir=tmp_path) is None
+    assert render_usage_plot("data", "QLever", output_dir=tmp_path) is None
     assert not (tmp_path / "data.resource-usage-plot.png").exists()
 
 
@@ -228,6 +228,6 @@ def test_render_usage_plot_falls_back_to_old_tsv_name(tmp_path):
     tsv_path.write_text(
         "elapsed_s\trss\tcpu_percent\n1.0\t100\t5.0\n2.0\t200\t6.0\n"
     )
-    plot_path = render_usage_plot("data", output_dir=tmp_path)
+    plot_path = render_usage_plot("data", "QLever", output_dir=tmp_path)
     assert plot_path == tmp_path / "data.resource-usage-plot.png"
     assert plot_path.exists()

--- a/test/qlever/test_footer.py
+++ b/test/qlever/test_footer.py
@@ -14,11 +14,11 @@ import pytest
 
 pytest.importorskip("textual")
 
-from textual import events  # noqa: E402
-from textual.app import App  # noqa: E402
-from textual.binding import Binding  # noqa: E402
+from textual import events
+from textual.app import App
+from textual.binding import Binding
 
-from qlever.monitor_queries.widgets.footer import Footer  # noqa: E402
+from qlever.monitor_queries.widgets.footer import Footer
 
 
 class CountingFooter(Footer):

--- a/test/qlever/test_footer.py
+++ b/test/qlever/test_footer.py
@@ -10,10 +10,6 @@ arriving while the terminal is unfocused is drawn on refocus.
 
 import asyncio
 
-import pytest
-
-pytest.importorskip("textual")
-
 from textual import events
 from textual.app import App
 from textual.binding import Binding


### PR DESCRIPTION
So far, the `qlever` commands took the script name and the engine name from `sys.argv[0]` (computed once in `qlever/__init__.py` and read as globals), and everywhere else the name `qlever` was simply spelled out in the help strings and in the messages that tell the user which command to run next.

Now the top-level parser provides three defaults, which the commands read from `args` like any other option: `engine_short_name` (used for the container names), `engine_display_name` (the name shown to the user), and `main_command_name` (what the user types before a command). All three are `qlever`/`QLever` for now and are set in one place in `config.py`. Nothing depends any more on how the script was invoked. In particular, the hook that imported engine-specific Qleverfile arguments from a module named after the script is removed. The output is unchanged, except that a few command descriptions no longer say `qlever index` or `qlever start`.

Also a number of small cleanups, such as replacing the deprecated `log.warn` by `log.warning`, moving `dict_to_yaml` to `util.py`, and applying the automatic fixes from `ruff 0.16`.