### PR TITLE
Fix timeout units and index stats width

### DIFF
--- a/src/qlever/commands/benchmark_queries.py
+++ b/src/qlever/commands/benchmark_queries.py
@@ -25,6 +25,7 @@ from qlever.util import (
     pretty_printed_query,
     run_command,
     run_curl_command,
+    timeout_seconds,
 )
 
 
@@ -868,10 +869,7 @@ class BenchmarkQueriesCommand(QleverCommand):
         width_query_name_half = args.width_query_name // 2
         width_query_name = 2 * width_query_name_half + 1
 
-        try:
-            timeout = int(args.timeout[:-1])
-        except ValueError:
-            timeout = None
+        timeout = timeout_seconds(args.timeout)
 
         benchmark_name, benchmark_description = resolve_benchmark_metadata(
             args.benchmark_name,

--- a/src/qlever/commands/index_stats.py
+++ b/src/qlever/commands/index_stats.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
 
@@ -10,6 +11,14 @@ from qlever.util import (
     iter_permutation_phases,
     parse_phase_markers,
 )
+
+
+def heading_width(headings: Iterable[str], min_width: int = 25) -> int:
+    """
+    Width of the heading column, so that the colons still line up for
+    engines with headings longer than `min_width`.
+    """
+    return max([min_width, *(len(heading) for heading in headings)])
 
 
 def compute_durations(
@@ -284,18 +293,32 @@ class IndexStatsCommand(QleverCommand):
 
     def execute(self, args) -> bool:
         return_value = True
+        log_file_name = f"{args.name}.index-log.txt"
 
-        # The "time" part of the command.
+        # The heading of the "time" part, shown before the log is parsed so
+        # that messages about a missing or incomplete log appear below it.
         if not args.only_space:
-            log_file_name = f"{args.name}.index-log.txt"
             self.show(
                 f"Breakdown of the time used for "
                 f"building the index, based on the timestamps for key "
                 f'lines in "{log_file_name}"',
                 only_show=args.show,
             )
-            if not args.show:
+
+        # Compute both breakdowns before printing either, so that the time
+        # and the space part pad their headings to a common width.
+        durations = {}
+        sizes = {}
+        if not args.show:
+            if not args.only_space:
                 durations = self.execute_time(args, log_file_name)
+            if not args.only_time:
+                sizes = self.execute_space(args)
+        width = heading_width([*durations, *sizes])
+
+        # The "time" part of the command.
+        if not args.only_space:
+            if not args.show:
                 # Display each phase duration, skipping phases with
                 # missing timestamps (duration is None).
                 for heading, (duration, time_unit) in durations.items():
@@ -303,7 +326,8 @@ class IndexStatsCommand(QleverCommand):
                         if heading == "TOTAL time" and len(durations) != 1:
                             log.info("")
                         log.info(
-                            f"{heading:<25} : {duration:>6.1f} {time_unit}"
+                            f"{heading:<{width}} : {duration:>6.1f} "
+                            f"{time_unit}"
                         )
                 return_value &= len(durations) != 0
             if not args.only_time:
@@ -316,15 +340,16 @@ class IndexStatsCommand(QleverCommand):
                 only_show=args.show,
             )
             if not args.show:
-                sizes = self.execute_space(args)
                 # Display the disk space used by each group of index files.
                 for heading, (size, size_unit) in sizes.items():
                     if heading == "TOTAL size" and len(sizes) != 1:
                         log.info("")
                     if size_unit == "B":
-                        log.info(f"{heading:<25} :  {size:,} {size_unit}")
+                        log.info(f"{heading:<{width}} :  {size:,} {size_unit}")
                     else:
-                        log.info(f"{heading:<25} : {size:>6.1f} {size_unit}")
+                        log.info(
+                            f"{heading:<{width}} : {size:>6.1f} {size_unit}"
+                        )
                 return_value &= len(sizes) != 0
 
         return return_value

--- a/src/qlever/commands/monitor_queries.py
+++ b/src/qlever/commands/monitor_queries.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from qlever.command import QleverCommand
 from qlever.log import log
 from qlever.monitor_queries.app import MonitorQueriesApp
+from qlever.util import timeout_seconds
 
 # `LiveLogReader` ingests new log lines every 0.2s, so a faster screen
 # refresh would only re-render the ticking duration; 0.2s is the floor.
@@ -100,16 +101,8 @@ class MonitorQueriesCommand(QleverCommand):
             log.error(f"Log file not found: {args.metrics_log}")
             return False
 
-        timeout_s = 30
+        timeout_s = timeout_seconds(args.timeout)
         if args.slow_threshold is None:
-            try:
-                timeout_s = int(args.timeout.rstrip("s"))
-            except ValueError:
-                log.error(
-                    f"Could not parse server timeout {args.timeout!r};"
-                    " pass --slow-threshold explicitly"
-                )
-                return False
             args.slow_threshold = max(1, timeout_s - 10)
 
         if args.refresh < REFRESH_MIN_S or args.refresh > REFRESH_MAX_S:

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from qlever import script_name
 from qlever.containerize import Containerize
 from qlever.log import log
-from qlever.util import positive_int
+from qlever.util import parse_timeout, positive_int
 
 
 def bool_type(val: str) -> bool:
@@ -354,11 +354,11 @@ class Qleverfile:
         )
         server_args["timeout"] = arg(
             "--timeout",
-            type=str,
+            type=parse_timeout,
             default="30s",
-            help="The maximal time in seconds a query is allowed to run"
-            " (can be increased per query with the URL parameters "
-            "`timeout` and `access_token`)",
+            help="The maximal time a query is allowed to run, for example "
+            "`30s` or `5min` (can be increased per query with the URL "
+            "parameters `timeout` and `access_token`)",
         )
         server_args["num_threads"] = arg(
             "--num-threads",

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -534,6 +534,39 @@ def parse_memory(value: str) -> str:
     return value.upper()
 
 
+# The timeout units the server accepts, in seconds. Case sensitive.
+TIMEOUT_UNIT_SECONDS = {
+    "ns": 1e-9,
+    "us": 1e-6,
+    "ms": 1e-3,
+    "s": 1,
+    "min": 60,
+    "h": 3600,
+}
+
+
+def parse_timeout(value: str) -> str:
+    """
+    Validate a timeout string like `180s` or `5min`.
+    """
+    if not re.fullmatch(r"\d+(ns|us|ms|s|min|h)", value):
+        raise argparse.ArgumentTypeError(
+            f"Invalid timeout `{value}`. Use a number followed by one of "
+            f"{', '.join(TIMEOUT_UNIT_SECONDS)}, for example `30s` or `5min`."
+        )
+    return value
+
+
+def timeout_seconds(value: str) -> int:
+    """
+    A timeout like `5min` as whole seconds, for engines that take a bare
+    number. Never 0, so a sub-second timeout stays a timeout. Expects a
+    value that `parse_timeout` has accepted.
+    """
+    number, unit = re.fullmatch(r"(\d+)(\D+)", value).groups()
+    return max(1, round(int(number) * TIMEOUT_UNIT_SECONDS[unit]))
+
+
 def container_memory_to_bytes(memory_string: str) -> int:
     """
     Parse a memory usage string from `docker stats` or `podman stats`

--- a/test/qlever/test_util.py
+++ b/test/qlever/test_util.py
@@ -6,7 +6,9 @@ from qlever.util import (
     container_memory_to_bytes,
     get_random_string,
     parse_git_hash,
+    parse_timeout,
     positive_int,
+    timeout_seconds,
 )
 
 
@@ -87,3 +89,49 @@ def test_parse_git_hash_empty_file(tmp_path):
     path = tmp_path / "empty.txt"
     path.write_text("")
     assert parse_git_hash(path) is None
+
+
+@pytest.mark.parametrize("value", ["5ns", "5us", "500ms", "30s", "5min", "2h"])
+def test_parse_timeout_accepts_every_unit(value):
+    assert parse_timeout(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # No unit at all.
+        "30",
+        # Unit the server does not accept.
+        "30sec",
+        # Wrong case, the server is case sensitive.
+        "30S",
+        "5MIN",
+        # Not a number.
+        "abc",
+        "",
+        # Fractional values are not supported.
+        "1.5s",
+        # Whitespace between number and unit.
+        "30 s",
+    ],
+)
+def test_parse_timeout_rejects(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_timeout(value)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("30s", 30),
+        ("5min", 300),
+        ("2h", 7200),
+        # Rounded to whole seconds.
+        ("1500ms", 2),
+        # Sub-second timeouts stay a timeout instead of becoming 0.
+        ("1ms", 1),
+        ("1ns", 1),
+    ],
+)
+def test_timeout_seconds(value, expected):
+    assert timeout_seconds(value) == expected


### PR DESCRIPTION
The `--timeout` of `qlever start` is passed on to the server, which accepts a unit (`ns`, `us`, `ms`, `s`, `min`, `h`). The commands that need the timeout seconds as a plain number, however, obtained it by cutting off the last character of the string, so anything but seconds broke them.

With this change, `--timeout` is validated when it is parsed, so an unusable value is rejected right away, with a message naming the units that are accepted, instead of failing later in whichever command happens to need a number. The conversion to whole seconds now happens in one place for all commands, and a sub-second timeout becomes one second rather than zero, so it stays a timeout.

On the side, the headings of `qlever index-stats` are now padded to the width of the longest heading (at least the previous 25 characters, so the QLever output is unchanged) and to the same width in the time and the space part, so that the colons still line up for engines whose phases and file groups have longer names.